### PR TITLE
Vite bundler dev mode enhancements.

### DIFF
--- a/.changeset/slimy-ravens-rule.md
+++ b/.changeset/slimy-ravens-rule.md
@@ -1,0 +1,5 @@
+---
+"alliance-platform-frontend": patch
+---
+
+Better handling for bundler dev server checks; avoid crashing on timeout, and handle false positive on dev server check on a read timeout.

--- a/.changeset/ten-dryers-battle.md
+++ b/.changeset/ten-dryers-battle.md
@@ -1,0 +1,6 @@
+---
+"alliance-platform-frontend": patch
+---
+
+Add `DEV_CODE_FORMAT_LIMIT` to limit the size of code the dev server will attempt to format (default 1mb).
+Add `DEV_CODE_FORMAT_TIMEOUT` to control the timeout applied to requests to the Vite dev server for formatting; defaults to 1 second.

--- a/packages/ap-frontend/alliance_platform/frontend/bundler/base.py
+++ b/packages/ap-frontend/alliance_platform/frontend/bundler/base.py
@@ -81,6 +81,8 @@ class DevServerCheck:
 
     #: True if dev server is running at the expected location (depends on the bundler)
     is_running: bool
+    #: Read timeout
+    read_timeout: bool = False
     #: The project dir the frontend dev server is running at. This is used to determine if it's for the same project as Django.
     project_dir: Path | None = None
 

--- a/packages/ap-frontend/alliance_platform/frontend/bundler/vite.py
+++ b/packages/ap-frontend/alliance_platform/frontend/bundler/vite.py
@@ -520,7 +520,10 @@ class ViteBundler(BaseBundler):
 
         In production this is a no-op for performance reasons.
         """
-        if self.is_development():
+        if self.is_development() and (
+            len(code) < ap_frontend_settings.DEV_CODE_FORMAT_LIMIT
+            or ap_frontend_settings.DEV_CODE_FORMAT_LIMIT == 0
+        ):
             if self.wait_for_server:
                 self.wait_for_server()
             payload = {"code": code}
@@ -529,7 +532,7 @@ class ViteBundler(BaseBundler):
                     urljoin(self.dev_server_url_base, "format-code"),
                     data=json.dumps(payload),
                     headers={"Content-Type": "application/json"},
-                    timeout=1,
+                    timeout=ap_frontend_settings.DEV_CODE_FORMAT_TIMEOUT,
                 )
                 if response.status_code != 200:
                     logger.error(

--- a/packages/ap-frontend/alliance_platform/frontend/bundler/vite.py
+++ b/packages/ap-frontend/alliance_platform/frontend/bundler/vite.py
@@ -510,8 +510,10 @@ class ViteBundler(BaseBundler):
             if r.status_code != 200:
                 return DevServerCheck(is_running=False)
             return DevServerCheck(is_running=True, project_dir=Path(r.json()["projectDir"]))
-        except requests.ConnectionError:
+        except (requests.ConnectionError, requests.ConnectTimeout):
             return DevServerCheck(is_running=False)
+        except requests.ReadTimeout:
+            return DevServerCheck(is_running=True, read_timeout=True)
 
     def format_code(self, code: str):
         """In dev format code using /format-code endpoint defined in dev-server.ts

--- a/packages/ap-frontend/alliance_platform/frontend/settings.py
+++ b/packages/ap-frontend/alliance_platform/frontend/settings.py
@@ -67,6 +67,12 @@ class AlliancePlatformFrontendSettingsType(TypedDict, total=False):
     REACT_RENDER_COMPONENT_FILE: Path | str
     #: Set to a dotted path to a function that will be called to resolve the global context for SSR. This function should return a dictionary of values to be passed to the SSR renderer under the `globalContext` key.
     SSR_GLOBAL_CONTEXT_RESOLVER: str | None
+    #: The limit to apply for code format requests in development mode. This is limited to 1mb by default; anything above that will not be formatted. This is only
+    #: applicable to dev mode where code is formatted to make debugging easier when viewing the source.
+    DEV_CODE_FORMAT_LIMIT: int | None
+    #: This is the timeout to apply for code format requests in development mode. This is limited to 1 seconds by default. The only time you should need to
+    #: tweak this is if you are attempting to debug issues with a large piece of code; in which case you likely need to increase ``DEV_CODE_FORMAT_LIMIT`` as well.
+    DEV_CODE_FORMAT_TIMEOUT: int | None
 
 
 def maybe_import_string(val: Any | None):
@@ -115,6 +121,12 @@ class AlliancePlatformFrontendSettings(AlliancePlatformSettingsBase):
     SSR_GLOBAL_CONTEXT_RESOLVER: str | None
     #: File that is used to render React components using the ``react`` tag. This file should export a function named ``renderComponent`` and a function ``createElementWithProps``.
     REACT_RENDER_COMPONENT_FILE: Path
+    #: The limit to apply for code format requests in development mode. This is limited to 1mb by default; anything above that will not be formatted. This is only
+    #: applicable to dev mode where code is formatted to make debugging easier when viewing the source.
+    DEV_CODE_FORMAT_LIMIT: int
+    #: This is the timeout to apply for code format requests in development mode. This is limited to 1 seconds by default. The only time you should need to
+    #: tweak this is if you are attempting to debug issues with a large piece of code; in which case you likely need to increase ``DEV_CODE_FORMAT_LIMIT`` as well.
+    DEV_CODE_FORMAT_TIMEOUT: int
 
     def check_settings(self):
         # TODO: Implement checks on required settings
@@ -137,6 +149,8 @@ DEFAULTS = {
     "BUNDLER_DISABLE_DEV_CHECK_HTML": True,
     "SSR_GLOBAL_CONTEXT_RESOLVER": None,
     "REACT_RENDER_COMPONENT_FILE": None,
+    "DEV_CODE_FORMAT_LIMIT": 1 * 1024 * 1024,
+    "DEV_CODE_FORMAT_TIMEOUT": 1,
 }
 
 

--- a/packages/ap-frontend/alliance_platform/frontend/templatetags/bundler.py
+++ b/packages/ap-frontend/alliance_platform/frontend/templatetags/bundler.py
@@ -313,6 +313,10 @@ def bundler_dev_checks():
             warnings.warn(
                 f"Bundler dev server was found but it's for project {check.project_dir}. You likely need to run `yarn dev` under {bundler.root_dir}"
             )
+        elif check.read_timeout:
+            warnings.warn(
+                "Received ReadTimeout from dev server check; dev server is likely running but no response was received within timeout to verify"
+            )
         if ap_frontend_settings.BUNDLER_DISABLE_DEV_CHECK_HTML:
             return ""
         return get_template("bundler_dev_check.html").render({"check": check})

--- a/packages/ap-frontend/tests/test_bundler.py
+++ b/packages/ap-frontend/tests/test_bundler.py
@@ -12,6 +12,8 @@ from django.conf import settings
 from django.test import TestCase
 from django.test import override_settings
 
+from tests.test_utils import override_ap_frontend_settings
+
 
 class TestBundler(TestCase):
     def test_relative_path_resolver(self):
@@ -56,6 +58,15 @@ class TestBundler(TestCase):
             None,
             resolver.resolve("/project/test.ts", ResolveContext(Path("/root"))),
         )
+
+
+class MockRequestResponse:
+    def __init__(self, json_data, status_code):
+        self.json_data = json_data
+        self.status_code = status_code
+
+    def json(self):
+        return self.json_data
 
 
 class TestViteBundler(ViteBundler):
@@ -272,3 +283,31 @@ class TestViteBundlerTestCase(TestCase):
             bundler.server_build_dir / "Button.mjs",
             bundler.resolve_ssr_import_path("components/Button.tsx"),
         )
+
+    def test_format_code_size_limit(self):
+        bundler = self.create_bundler(mode="development")
+
+        def mocked_post(*args, **kwargs):
+            return MockRequestResponse({"code": "formatted"}, 200)
+
+        with mock.patch("requests.post", side_effect=mocked_post):
+            self.assertEqual(bundler.format_code("a short string"), "formatted")
+            long_string = "." * 1024 * 1024
+            self.assertEqual(bundler.format_code(long_string), long_string)
+            with override_ap_frontend_settings(DEV_CODE_FORMAT_LIMIT=0):
+                self.assertEqual(bundler.format_code(long_string), "formatted")
+
+    def test_format_code_timeout(self):
+        bundler = self.create_bundler(mode="development")
+
+        def mocked_post(*args, **kwargs):
+            return MockRequestResponse({"code": "formatted"}, 200)
+
+        with mock.patch("requests.post", side_effect=mocked_post) as mock_send:
+            bundler.format_code("code")
+            self.assertEqual(mock_send.call_args.kwargs.get("timeout"), 1)
+
+        with mock.patch("requests.post", side_effect=mocked_post) as mock_send:
+            with override_ap_frontend_settings(DEV_CODE_FORMAT_TIMEOUT=10):
+                bundler.format_code("code")
+                self.assertEqual(mock_send.call_args.kwargs.get("timeout"), 10)


### PR DESCRIPTION
I encountered an error on a project where the dev server check in django failed with a timeout, but didn't handle the timeout and so crashed. This fixes that check to handle the timeout, and specifically handle `ReadTimeout` separately to `ConnectionTimeout` (read timeout means the dev server is running, but didn't respond in time - so we shouldn't show the dev server not running warning, but will log a message about the timeout).

The thing that caused the dev server to timeout however was a request to format code that was 5mb ... this tied up the dev server and caused the otherwise  trivial dev server check to timeout. This large formatting request then also timed out anyway, but that was handled gracefully and everything still worked. I've introduced a setting to limit the request size, defaults to 1mb. This only stops the code from being formatted; which is something we do in dev only to give a prettier 'view soruce' experience which is easier to debug.
