### PR TITLE
Properly handle HTML within component tags

### DIFF
--- a/.changeset/bright-avocados-marry.md
+++ b/.changeset/bright-avocados-marry.md
@@ -1,0 +1,5 @@
+---
+"alliance-platform-frontend": patch
+---
+
+Support LazyObject as a prop. This will unwrap the lazy object; the underlying value must be a valid prop type otherwise an error will be thrown. This allows things like the default `csrf_token` context variable to be passed.

--- a/.changeset/gentle-stingrays-drop.md
+++ b/.changeset/gentle-stingrays-drop.md
@@ -1,0 +1,5 @@
+---
+"alliance-platform-codegen": patch
+---
+
+Support for JSX in `TypescriptPrinter`, comments on nodes, and better handling of strings to avoid unnecessary conversion to ASCII.

--- a/.changeset/swift-melons-shout.md
+++ b/.changeset/swift-melons-shout.md
@@ -1,0 +1,5 @@
+---
+"alliance-platform-frontend": patch
+---
+
+Support HTML directly within React components

--- a/.changeset/tricky-pots-check.md
+++ b/.changeset/tricky-pots-check.md
@@ -1,0 +1,5 @@
+---
+"alliance-platform-frontend": patch
+---
+
+React component tag codegen implementation has changed. To support latest changes, `REACT_RENDER_COMPONENT_FILE` should now export `createElement` from React directly; `createElementWithProps` is no longer used. `renderComponent` should accept an element to render rather than a component & props as separate arguments. SSR code should manually call `createElement` by extracting `children` from `props` and spreading them in the `createElement` call. Any custom `ComponentProp` classes can remove the `as_debug_string` method; it's no longer used.

--- a/packages/ap-codegen/alliance_platform/codegen/printer.py
+++ b/packages/ap-codegen/alliance_platform/codegen/printer.py
@@ -206,7 +206,7 @@ class TypescriptPrinter:
             return f"{{{prefix}{value}{suffix}}}"
         if isinstance(node, JsxElement):
             if self.jsx_transform:
-                args = [
+                element_args: list[NodeLike] = [
                     node.tag_name,
                     ObjectLiteralExpression(
                         [
@@ -225,7 +225,7 @@ class TypescriptPrinter:
                 return self.print(
                     CallExpression(
                         self.jsx_transform,
-                        args,
+                        element_args,
                     )
                 )
             attrs = []

--- a/packages/ap-codegen/alliance_platform/codegen/typescript.py
+++ b/packages/ap-codegen/alliance_platform/codegen/typescript.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import re
 from typing import Callable
 from typing import Sequence
+from typing import Union
 
 from django.utils.functional import Promise
 
@@ -11,10 +12,12 @@ from django.utils.functional import Promise
 # We don't need to be strict so exclude things where it makes it easier to use
 
 
+@dataclass(kw_only=True)
 class Node:
     """Root node everything else should extend from"""
 
-    pass
+    leading_comments: list[Union["SingleLineComment", "MultiLineComment"]] | None = None
+    trailing_comments: list[Union["SingleLineComment", "MultiLineComment"]] | None = None
 
 
 class Modifier:
@@ -587,6 +590,11 @@ class SingleLineComment(Node):
 
 
 @dataclass
+class MultiLineComment(Node):
+    comment_text: str
+
+
+@dataclass
 class NewExpression(Node):
     expression: Node
     arguments: Sequence[NodeLike] = field(default_factory=list)
@@ -605,6 +613,34 @@ class ArrowFunction(Node):
     parameters: list[Parameter]
     #: The body as either a single expression valid for Arrow functions or a ``Block`` node
     body: Node
+
+
+@dataclass
+class JsxAttribute(Node):
+    name: Identifier | StringLiteral
+    initializer: Node
+
+
+@dataclass
+class JsxSpreadAttribute(Node):
+    expression: Identifier
+
+
+@dataclass
+class JsxText(Node):
+    value: str
+
+
+@dataclass
+class JsxExpression(Node):
+    expression: Node | None
+
+
+@dataclass
+class JsxElement(Node):
+    tag_name: Identifier | StringLiteral
+    attributes: Sequence[JsxAttribute | JsxSpreadAttribute]
+    children: list[Union[JsxText, JsxExpression, "JsxElement"]]
 
 
 def construct_object_property_key(

--- a/packages/ap-codegen/alliance_platform/codegen/typescript.py
+++ b/packages/ap-codegen/alliance_platform/codegen/typescript.py
@@ -16,8 +16,8 @@ from django.utils.functional import Promise
 class Node:
     """Root node everything else should extend from"""
 
-    leading_comments: list[Union["SingleLineComment", "MultiLineComment"]] | None = None
-    trailing_comments: list[Union["SingleLineComment", "MultiLineComment"]] | None = None
+    leading_comments: Sequence[Union["SingleLineComment", "MultiLineComment"]] | None = None
+    trailing_comments: Sequence[Union["SingleLineComment", "MultiLineComment"]] | None = None
 
 
 class Modifier:

--- a/packages/ap-codegen/tests/test_printer.py
+++ b/packages/ap-codegen/tests/test_printer.py
@@ -16,6 +16,7 @@ from alliance_platform.codegen.typescript import ImportDefaultSpecifier
 from alliance_platform.codegen.typescript import ImportSpecifier
 from alliance_platform.codegen.typescript import JsxAttribute
 from alliance_platform.codegen.typescript import JsxElement
+from alliance_platform.codegen.typescript import JsxSpreadAttribute
 from alliance_platform.codegen.typescript import JsxText
 from alliance_platform.codegen.typescript import MultiLineComment
 from alliance_platform.codegen.typescript import NewExpression
@@ -434,6 +435,31 @@ class TypescriptPrinterTestCase(SimpleTestCase):
                             Identifier("Button"),
                             [],
                             [JsxText("This & that")],
+                        )
+                    ),
+                    expected,
+                )
+
+    def test_jsx_spread_attribute(self):
+        tests = [
+            (None, "<Button isDisabled={true} {...props}>Click Me</Button>"),
+            (
+                Identifier("createElement"),
+                'createElement(Button, {isDisabled: true, ...props}, "Click Me")',
+            ),
+        ]
+        for jsx_transform, expected in tests:
+            with self.subTest(jsx_transform=jsx_transform):
+                p = TypescriptPrinter(jsx_transform=jsx_transform)
+                self.assertEqual(
+                    p.print(
+                        JsxElement(
+                            Identifier("Button"),
+                            [
+                                JsxAttribute(Identifier("isDisabled"), BooleanLiteral(True)),
+                                JsxSpreadAttribute(Identifier("props")),
+                            ],
+                            [JsxText("Click Me")],
                         )
                     ),
                     expected,

--- a/packages/ap-codegen/tests/test_printer.py
+++ b/packages/ap-codegen/tests/test_printer.py
@@ -3,6 +3,7 @@ import textwrap
 from alliance_platform.codegen.printer import TypescriptPrinter
 from alliance_platform.codegen.printer import TypescriptSourceFileWriter
 from alliance_platform.codegen.typescript import ArrayLiteralExpression
+from alliance_platform.codegen.typescript import ArrowFunction
 from alliance_platform.codegen.typescript import AsExpression
 from alliance_platform.codegen.typescript import AsyncKeyword
 from alliance_platform.codegen.typescript import BooleanLiteral
@@ -16,6 +17,7 @@ from alliance_platform.codegen.typescript import ImportDefaultSpecifier
 from alliance_platform.codegen.typescript import ImportSpecifier
 from alliance_platform.codegen.typescript import JsxAttribute
 from alliance_platform.codegen.typescript import JsxElement
+from alliance_platform.codegen.typescript import JsxExpression
 from alliance_platform.codegen.typescript import JsxSpreadAttribute
 from alliance_platform.codegen.typescript import JsxText
 from alliance_platform.codegen.typescript import MultiLineComment
@@ -529,6 +531,34 @@ class TypescriptPrinterTestCase(SimpleTestCase):
                             ],
                             leading_comments=[SingleLineComment("Leading comment")],
                             trailing_comments=[SingleLineComment("Trailing comment")],
+                        )
+                    ),
+                    expected,
+                )
+
+    def test_jsx_function_children(self):
+        tests = [
+            (None, "<Provider>{() => <span>child</span>}</Provider>"),
+            (
+                Identifier("createElement"),
+                'createElement(Provider, {}, () => createElement("span", {}, "child"))',
+            ),
+        ]
+        for jsx_transform, expected in tests:
+            with self.subTest(jsx_transform=jsx_transform):
+                p = TypescriptPrinter(jsx_transform=jsx_transform)
+                self.assertEqual(
+                    p.print(
+                        JsxElement(
+                            Identifier("Provider"),
+                            [],
+                            [
+                                JsxExpression(
+                                    ArrowFunction(
+                                        [], JsxElement(StringLiteral("span"), [], [JsxText("child")])
+                                    )
+                                )
+                            ],
                         )
                     ),
                     expected,

--- a/packages/ap-frontend/alliance_platform/frontend/prop_handlers.py
+++ b/packages/ap-frontend/alliance_platform/frontend/prop_handlers.py
@@ -60,13 +60,6 @@ class ComponentProp(SSRCustomFormatSerializable, CodeGeneratorNode):
     defined in ``ssrJsonRevivers.tsx``.
     """
 
-    def as_debug_string(self):
-        """Return prop as a string for debugging purposes.
-
-        This is outputted in the template in dev to better illustrate how the component and props are constructed.
-        """
-        raise NotImplementedError(f"as_debug_string not implemented for {self.__class__.__name__}")
-
     @classmethod
     def should_apply(cls, value: Any, node: ComponentNode, context: Context):
         """Return ``True`` if this prop handler should be used for the given value."""
@@ -98,9 +91,6 @@ class DateProp(ComponentProp):
             "frontend/src/re-exports.tsx", ImportSpecifier("CalendarDate")
         )
         return NewExpression(calendar_date, self.js_args)
-
-    def as_debug_string(self):
-        return f'new CalendarDate({", ".join(map(str, self.js_args))})'
 
     @classmethod
     def should_apply(cls, value: Any, node: ComponentNode, context: Context):
@@ -139,9 +129,6 @@ class DateTimeProp(ComponentProp):
             calendar_date,
             self.js_args,
         )
-
-    def as_debug_string(self):
-        return f'new CalendarDateTime({", ".join(map(str, self.js_args))})'
 
     @classmethod
     def should_apply(cls, value: Any, node: ComponentNode, context: Context):
@@ -188,9 +175,6 @@ class ZonedDateTimeProp(ComponentProp):
             self.js_args,
         )
 
-    def as_debug_string(self):
-        return f"new ZonedDateTime({', '.join(map(str, self.js_args))})"
-
     @classmethod
     def should_apply(cls, value: Any, node: ComponentNode, context: Context):
         return isinstance(value, datetime.datetime) and is_aware(value)
@@ -216,9 +200,6 @@ class TimeProp(ComponentProp):
         calendar_date = generator.resolve_prop_import("frontend/src/re-exports.tsx", ImportSpecifier("Time"))
         return NewExpression(calendar_date, self.js_args)
 
-    def as_debug_string(self):
-        return f'new Time({", ".join(map(str, self.js_args))})'
-
     @classmethod
     def should_apply(cls, value: Any, node: ComponentNode, context: Context):
         return isinstance(value, datetime.time)
@@ -240,9 +221,6 @@ class SetProp(ComponentProp):
             Identifier("Set"),
             [ArrayLiteralExpression([self.convert_to_node(value, generator) for value in self.value])],
         )
-
-    def as_debug_string(self):
-        return f"new Set({list(self.value)})"
 
     @classmethod
     def should_apply(cls, value: Any, node: ComponentNode, context: Context):
@@ -274,11 +252,6 @@ class SpecialNumeric(ComponentProp):
         return Identifier("NaN")
 
     def get_representation(self, context: SSRSerializerContext) -> dict | str | list:
-        if math.isinf(self.value):
-            return "Infinity" if self.value > 0 else "-Infinity"
-        return "NaN"
-
-    def as_debug_string(self):
         if math.isinf(self.value):
             return "Infinity" if self.value > 0 else "-Infinity"
         return "NaN"

--- a/packages/ap-frontend/alliance_platform/frontend/settings.py
+++ b/packages/ap-frontend/alliance_platform/frontend/settings.py
@@ -63,7 +63,7 @@ class AlliancePlatformFrontendSettingsType(TypedDict, total=False):
     PRODUCTION_DIR: Path
     #: Any custom prop handlers to use for react components. This can be a string import path to a list of prop handlers, or the list directly.
     REACT_PROP_HANDLERS: str | list[type["ComponentProp"]]
-    #: File that is used to render React components using the ``react`` tag. This file should export a function named ``renderComponent`` and a function ``createElementWithProps``.
+    #: File that is used to render React components using the ``react`` tag. This file should export a function named ``renderComponent`` and a function ``createElement`` (this can just be re-exported from React).
     REACT_RENDER_COMPONENT_FILE: Path | str
     #: Set to a dotted path to a function that will be called to resolve the global context for SSR. This function should return a dictionary of values to be passed to the SSR renderer under the `globalContext` key.
     SSR_GLOBAL_CONTEXT_RESOLVER: str | None
@@ -119,7 +119,7 @@ class AlliancePlatformFrontendSettings(AlliancePlatformSettingsBase):
     BUNDLER_DISABLE_DEV_CHECK_HTML: bool
     #: Set to a dotted path to a function that will be called to resolve the global context for SSR. This function should return a dictionary of values to be passed to the SSR renderer under the `globalContext` key.
     SSR_GLOBAL_CONTEXT_RESOLVER: str | None
-    #: File that is used to render React components using the ``react`` tag. This file should export a function named ``renderComponent`` and a function ``createElementWithProps``.
+    #: File that is used to render React components using the ``react`` tag. This file should export a function named ``renderComponent`` and a function ``createElement`` (this can just be re-exported from React).
     REACT_RENDER_COMPONENT_FILE: Path
     #: The limit to apply for code format requests in development mode. This is limited to 1mb by default; anything above that will not be formatted. This is only
     #: applicable to dev mode where code is formatted to make debugging easier when viewing the source.

--- a/packages/ap-frontend/alliance_platform/frontend/templatetags/react.py
+++ b/packages/ap-frontend/alliance_platform/frontend/templatetags/react.py
@@ -758,7 +758,7 @@ class ComponentSourceCodeGenerator:
                 )
             )
             component_id = wrapper_id
-            jsx_element = (JsxElement(component_id, [], []),)
+            jsx_element = JsxElement(component_id, [], [])
         self._writer.add_node(
             CallExpression(
                 self._writer.resolve_import(

--- a/packages/ap-frontend/alliance_platform/frontend/templatetags/react.py
+++ b/packages/ap-frontend/alliance_platform/frontend/templatetags/react.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 from typing import Callable
 from typing import Union
+from typing import cast
 import warnings
 
 from alliance_platform.codegen.printer import TypescriptPrinter
@@ -702,7 +703,10 @@ class ComponentSourceCodeGenerator:
         self._last_template_origin_name = template_name
 
         try:
-            children = resolved_props.props.get("children", [])
+            children = cast(
+                list[NestedComponentProp | str] | str | NestedComponentProp,
+                resolved_props.props.get("children", []),
+            )
             attributes = [
                 JsxAttribute(
                     StringLiteral(key) if "-" in key else Identifier(underscore_to_camel(key)),

--- a/packages/ap-frontend/alliance_platform/frontend/templatetags/react.py
+++ b/packages/ap-frontend/alliance_platform/frontend/templatetags/react.py
@@ -21,9 +21,11 @@ from alliance_platform.codegen.typescript import ImportDefaultSpecifier
 from alliance_platform.codegen.typescript import ImportSpecifier
 from alliance_platform.codegen.typescript import JsxAttribute
 from alliance_platform.codegen.typescript import JsxElement
+from alliance_platform.codegen.typescript import MultiLineComment
 from alliance_platform.codegen.typescript import PropertyAccessExpression
 from alliance_platform.codegen.typescript import ReturnStatement
 from alliance_platform.codegen.typescript import StringLiteral
+from alliance_platform.codegen.typescript import UnconvertibleValueException
 from alliance_platform.codegen.typescript import convert_to_node
 from allianceutils.template import build_html_attrs
 from allianceutils.template import is_static_expression
@@ -46,8 +48,6 @@ from django.utils.html import format_html
 from django.utils.safestring import SafeString
 from django.utils.safestring import mark_safe
 
-from ...codegen.typescript import MultiLineComment
-from ...codegen.typescript import UnconvertibleValueException
 from ..bundler import get_bundler
 from ..bundler.base import BaseBundler
 from ..bundler.base import ResolveContext
@@ -203,7 +203,7 @@ def component(parser: template.base.Parser, token: template.base.Token):
     - ``container:tag`` - the HTML tag to use for the container. Defaults to the custom element ``dj-component``.
     - ``container:<any other prop>`` - any other props will be passed to the container element. For example, to add
       an id to the container you can use ``container:id="my-id"``. Note that while you can pass a style string, it's
-      likely to be of little use with the default container style ``display: contents``. Most the time you can just
+      likely to be of little use with the default container style ``display: contents``. Most of the time you can just
       do the styling on the component itself.
 
     For example::
@@ -709,7 +709,7 @@ class ComponentSourceCodeGenerator:
             )
             attributes = [
                 JsxAttribute(
-                    StringLiteral(key) if "-" in key else Identifier(underscore_to_camel(key)),
+                    StringLiteral(key.lower()) if "-" in key else Identifier(underscore_to_camel(key)),
                     self._codegen_prop(prop),
                 )
                 for key, prop in resolved_props.props.items()

--- a/packages/ap-frontend/alliance_platform/frontend/templatetags/react.py
+++ b/packages/ap-frontend/alliance_platform/frontend/templatetags/react.py
@@ -34,6 +34,7 @@ from django.template import Origin
 from django.template import TemplateSyntaxError
 from django.template.base import UNKNOWN_SOURCE
 from django.template.base import FilterExpression
+from django.utils.functional import LazyObject
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 
@@ -73,6 +74,9 @@ def resolve_prop(value: Any, node: ComponentNode, context: Context) -> Component
         return list(resolve_prop(v, node, context) for v in value)
     if isinstance(value, ModelChoiceIteratorValue):
         return resolve_prop(value.value, node, context)  # type: ignore[attr-defined] # It has this value but no type info
+    if isinstance(value, LazyObject):
+        # unwrap lazy objects
+        return value.__reduce__()[1][0]
     for handler in ap_frontend_settings.REACT_PROP_HANDLERS:
         if handler.should_apply(value, node, context):
             return handler(value, node, context)

--- a/packages/ap-frontend/test_alliance_platform_frontend/templates/react_test_templates/nested_raw_tag.html
+++ b/packages/ap-frontend/test_alliance_platform_frontend/templates/react_test_templates/nested_raw_tag.html
@@ -1,0 +1,1 @@
+<strong>{{ name }}</strong>

--- a/packages/ap-frontend/test_alliance_platform_frontend/templates/react_test_templates/nested_tag.html
+++ b/packages/ap-frontend/test_alliance_platform_frontend/templates/react_test_templates/nested_tag.html
@@ -1,0 +1,2 @@
+{% load react %}
+{% component "strong" %}{{ name }}{% endcomponent %}

--- a/packages/ap-frontend/test_alliance_platform_frontend/templates/react_test_templates/simple_include.html
+++ b/packages/ap-frontend/test_alliance_platform_frontend/templates/react_test_templates/simple_include.html
@@ -1,0 +1,1 @@
+Inner Content

--- a/packages/ap-frontend/tests/test_bundler_templatetags.py
+++ b/packages/ap-frontend/tests/test_bundler_templatetags.py
@@ -336,7 +336,7 @@ class TestVanillaExtractTemplateTag(SimpleTestCase):
 
 
 @override_ap_frontend_settings(DEBUG_COMPONENT_OUTPUT=False)
-class TestComponentTemplateTag(SimpleTestCase):
+class TestComponentTemplateTagCodeGen(SimpleTestCase):
     def setUp(self) -> None:
         self.test_production_bundler = TestViteBundler(
             **bundler_kwargs,  # type: ignore[arg-type]
@@ -368,12 +368,11 @@ class TestComponentTemplateTag(SimpleTestCase):
                 f"""
                     <dj-component data-djid="C1"><!-- ___SSR_PLACEHOLDER_0___ --></dj-component>
                     <script type="module">
-                        import {{ renderComponent }} from '{self.dev_url}frontend/src/renderComponent.tsx';
+                        import {{ createElement, renderComponent }} from '{self.dev_url}frontend/src/renderComponent.tsx';
                         import Button, {{  }} from '{self.dev_url}components/Button.tsx';
                         renderComponent(
                           document.querySelector("[data-djid='C1']"),
-                          Button,
-                          {{ children: "Click Me" }},
+                          createElement(Button, {{}}, "Click Me"),
                           "C1",
                           true
                         );
@@ -386,9 +385,11 @@ class TestComponentTemplateTag(SimpleTestCase):
                 """
                     <dj-component data-djid="C1"><!-- ___SSR_PLACEHOLDER_0___ --></dj-component>
                     <script type="module">
-                        import { renderComponent } from '/static/assets/renderComponent-e1.js';
+                        import { createElement, renderComponent } from '/static/assets/renderComponent-e1.js';
                         import Button, {  } from '/static/assets/Button-def456.js';
-                        renderComponent(document.querySelector("[data-djid='C1']"), Button, {children: "Click Me"}, "C1", true)
+                        renderComponent(
+                            document.querySelector("[data-djid='C1']"),
+                            createElement(Button, {}, "Click Me"), "C1", true)
                     </script>
                 """,
             ),
@@ -437,13 +438,12 @@ class TestComponentTemplateTag(SimpleTestCase):
                         """
                         <dj-component data-djid="C1"><!-- ___SSR_PLACEHOLDER_0___ --></dj-component>
                         <script type="module">
-                            import { createElementWithProps, renderComponent } from "%sfrontend/src/renderComponent.tsx";
+                            import { createElement, renderComponent } from "%sfrontend/src/renderComponent.tsx";
                             import Button from "%scomponents/Button.tsx";
 
                             renderComponent(
                               document.querySelector("[data-djid='C1']"),
-                              Button,
-                              { children: ["Click ", createElementWithProps("strong", {children: "Me"})] },
+                              createElement(Button, {}, "Click ", createElement("strong", {}, "Me")),
                               "C1",
                               true
                             );
@@ -540,7 +540,7 @@ class TestComponentTemplateTag(SimpleTestCase):
                     )
                     actual = tpl.render(context)
                     self.assertIn(
-                        """renderComponent(document.querySelector("[data-djid='C1']"), "button", {disabled: true, children: "Click", "aria-label": "Click Me", date: new CalendarDate(2022, 12, 1)}, "C1", true)""",
+                        """renderComponent(document.querySelector("[data-djid='C1']"), createElement("button", {disabled: true, "aria-label": "Click Me", date: new CalendarDate(2022, 12, 1)}, "Click"), "C1", true)""",
                         actual,
                     )
 

--- a/packages/ap-frontend/tests/test_bundler_templatetags.py
+++ b/packages/ap-frontend/tests/test_bundler_templatetags.py
@@ -19,6 +19,7 @@ from django.test import SimpleTestCase
 from django.test import override_settings
 from django.utils.functional import SimpleLazyObject
 from django.utils.functional import lazy
+from django.utils.safestring import mark_safe
 from django.utils.timezone import make_aware
 
 from .test_utils import override_ap_frontend_settings
@@ -908,4 +909,19 @@ class TestComponentTemplateTagOutput(SimpleTestCase):
             {% component "Button" icon=icon %}Click{% endcomponent %}""",
             """<Button icon={<Icon />}>Click</Button>""",
             name="Sam",
+        )
+
+    def test_html_in_var(self):
+        self.assertComponentEqual(
+            """
+            {% component "div" %}{{ text }}{% endcomponent %}""",
+            """<div><strong>Should not be escaped</strong></div>""",
+            text=mark_safe("<strong>Should not be escaped</strong>"),
+        )
+
+        self.assertComponentEqual(
+            """
+            {% component "div" %}{{ text }}{% endcomponent %}""",
+            """<div>{'<strong>Should be escaped</strong>'}</div>""",
+            text="<strong>Should be escaped</strong>",
         )

--- a/packages/ap-frontend/tests/test_bundler_templatetags.py
+++ b/packages/ap-frontend/tests/test_bundler_templatetags.py
@@ -15,6 +15,8 @@ from django.template import Context
 from django.template import Template
 from django.test import SimpleTestCase
 from django.test import override_settings
+from django.utils.functional import SimpleLazyObject
+from django.utils.functional import lazy
 from django.utils.timezone import make_aware
 
 from .test_utils import override_ap_frontend_settings
@@ -756,6 +758,32 @@ class TestComponentTemplateTagOutput(SimpleTestCase):
         self.assertEqual(
             run_prettier(self._get_debug_tree(template_code, **kwargs)),
             run_prettier(expected_output),
+        )
+
+    def test_django_lazy_object_as_prop(self):
+        def get_token():
+            return "abc123"
+
+        token = lazy(get_token, str)
+        self.assertComponentEqual(
+            """{% component "CustomForm" csrf_token=csrf_token %}{% endcomponent %}""",
+            """
+            <CustomForm csrfToken="abc123" />
+            """,
+            csrf_token=token,
+        )
+
+    def test_django_simple_lazy_object_as_prop(self):
+        def get_token():
+            return "abc123"
+
+        token = SimpleLazyObject(get_token)
+        self.assertComponentEqual(
+            """{% component "CustomForm" csrf_token=csrf_token %}{% endcomponent %}""",
+            """
+            <CustomForm csrfToken="abc123" />
+            """,
+            csrf_token=token,
         )
 
     def test_variable_string_concat(self):

--- a/packages/ap-frontend/tests/test_utils/bundler.py
+++ b/packages/ap-frontend/tests/test_utils/bundler.py
@@ -26,14 +26,14 @@ def run_prettier(code):
         [
             str(ap_frontend_settings.NODE_MODULES_DIR / ".bin/prettier"),
             "--stdin-filepath",
-            "test.ts",
+            "test.tsx",
         ],
         input=code,
         capture_output=True,
         text=True,
     )
     if p.returncode != 0:
-        raise ValueError("Failed to format code")
+        raise ValueError(f"Failed to format code: {p.stderr}")
     return p.stdout
 
 


### PR DESCRIPTION
The main commit for HTML support is 60cd91f, however the commits prior refactored some code to make the changes easier to implement & test.

Specifically, with codegen we can now define JSX directly and then have the printer either output it as JSX (good for testing, debugging), or as `createElement` calls used in the browser.

Commit by commit review is recommended.