### PR TITLE
fix: Properly handle comments within JSX attributes

### DIFF
--- a/.changeset/heavy-pets-sleep.md
+++ b/.changeset/heavy-pets-sleep.md
@@ -1,0 +1,5 @@
+---
+"alliance-platform-frontend": patch
+---
+
+Fix typing for `ComponentSourceCodeGenerator.add_leading_node`

--- a/.changeset/short-glasses-confess.md
+++ b/.changeset/short-glasses-confess.md
@@ -1,0 +1,5 @@
+---
+"alliance-platform-codegen": patch
+---
+
+Properly handle comments within JSX attributes like `<Input description={/* comment here */<Inner />} />`

--- a/packages/ap-codegen/alliance_platform/codegen/printer.py
+++ b/packages/ap-codegen/alliance_platform/codegen/printer.py
@@ -554,11 +554,11 @@ class TypescriptSourceFileWriter:
         self.used_identifiers.append(specifier.local.name)
         return specifier.local
 
-    def add_node(self, node):
+    def add_node(self, node: Node):
         """Add a node to be included in the code"""
         self.nodes.append(node)
 
-    def add_leading_node(self, node):
+    def add_leading_node(self, node: Node):
         self.leading_nodes.append(node)
 
     def __enter__(self):

--- a/packages/ap-codegen/tests/test_printer.py
+++ b/packages/ap-codegen/tests/test_printer.py
@@ -564,6 +564,42 @@ class TypescriptPrinterTestCase(SimpleTestCase):
                     expected,
                 )
 
+    def test_jsx_comments_attribute(self):
+        tests = [
+            (None, "<Wrapper element={\n/* Leading comment */\n<Inner />} />"),
+            (
+                Identifier("createElement"),
+                'createElement(Wrapper, {"element": createElement(\n'
+                "/* Leading comment */\n"
+                "Inner, {})})",
+            ),
+        ]
+        for jsx_transform, expected in tests:
+            with self.subTest(jsx_transform=jsx_transform):
+                p = TypescriptPrinter(jsx_transform=jsx_transform)
+                self.assertEqual(
+                    p.print(
+                        JsxElement(
+                            Identifier("Wrapper"),
+                            [
+                                JsxAttribute(
+                                    StringLiteral(
+                                        "element",
+                                    ),
+                                    JsxElement(
+                                        Identifier("Inner"),
+                                        [],
+                                        [],
+                                        leading_comments=[MultiLineComment("Leading comment")],
+                                    ),
+                                )
+                            ],
+                            [],
+                        )
+                    ),
+                    expected,
+                )
+
 
 fixtures_dir = settings.BASE_DIR / "alliance_platform_frontend/bundler/tests/fixtures"
 


### PR DESCRIPTION
When printing comments within a jsx attribute the printer was incorrectly wrapping them in curly braces like a JSX expression, despite already being within a JSX expression