### PR TITLE
fix: handle nested html in vars

### DIFF
--- a/.changeset/quick-maps-punch.md
+++ b/.changeset/quick-maps-punch.md
@@ -1,0 +1,5 @@
+---
+"alliance-platform-frontend": patch
+---
+
+Properly handle nested HTML in template vars used with a {% component %} tag

--- a/packages/ap-frontend/tests/test_bundler_templatetags.py
+++ b/packages/ap-frontend/tests/test_bundler_templatetags.py
@@ -925,3 +925,11 @@ class TestComponentTemplateTagOutput(SimpleTestCase):
             """<div>{'<strong>Should be escaped</strong>'}</div>""",
             text="<strong>Should be escaped</strong>",
         )
+
+    def test_html_in_var_nested(self):
+        self.assertComponentEqual(
+            """
+            {% component "div" %}{{ text }}{% endcomponent %}""",
+            """<div><strong>Should not be <i>escaped</i></strong></div>""",
+            text=mark_safe("<strong>Should not be <i>escaped</i></strong>"),
+        )


### PR DESCRIPTION
When a var contained nested elements (e.g. `<div><i>...</i></div>`) thing broke because NestedComponentProp ended up being in children lists for the nested component. This change processes the nested component to a string immediately.