### PR TITLE
fix: handle template nodes in component props

### DIFF
--- a/.changeset/bright-poets-suffer.md
+++ b/.changeset/bright-poets-suffer.md
@@ -1,0 +1,5 @@
+---
+"alliance-platform-frontend": patch
+---
+
+Handle resolving template nodes used as props to raw html like `<a href="{% url "url-name" %}">...</a>`

--- a/packages/ap-frontend/alliance_platform/frontend/templatetags/react.py
+++ b/packages/ap-frontend/alliance_platform/frontend/templatetags/react.py
@@ -959,6 +959,11 @@ class ComponentNode(template.Node, BundlerAsset):
         If you add new :class:`~alliance_platform.frontend.prop_handlers.ComponentProp` there must a case here
         to convert values to the new type.
         """
+
+        # In the case of raw HTML that is transformed with the ``convert_html_string`` function we need to handle
+        # the case of a template node being used as a prop, e.g. ``<a href="{% url 'some-url' %}">``.
+        if isinstance(value, Node):
+            value = value.render(context)
         if isinstance(value, DeferredProp):
             value = value.resolve(context)
         if isinstance(value, (ChildrenList, NodeList)):

--- a/packages/ap-frontend/tests/test_bundler_templatetags.py
+++ b/packages/ap-frontend/tests/test_bundler_templatetags.py
@@ -933,3 +933,12 @@ class TestComponentTemplateTagOutput(SimpleTestCase):
             """<div><strong>Should not be <i>escaped</i></strong></div>""",
             text=mark_safe("<strong>Should not be <i>escaped</i></strong>"),
         )
+
+    def test_html_template_node_props(self):
+        """Tests that a template node is resolved when used as a prop to raw HTML"""
+        self.assertComponentEqual(
+            """
+            {% component "div" %}<a href="{{ url }}">Test</a>{% endcomponent %}""",
+            """<div><a href="/test/">Test</a></div>""",
+            url="/test/",
+        )


### PR DESCRIPTION
Handle the case of raw HTML that get's transformed because it's contained within a component tag having django template nodes as props. For example, `<a href="{% url 'some-url' %}">`.