### PR TITLE
fix: component tag pass through ssr disabled status

### DIFF
--- a/.changeset/poor-walls-draw.md
+++ b/.changeset/poor-walls-draw.md
@@ -1,0 +1,5 @@
+---
+"alliance-platform-frontend": patch
+---
+
+Fix so `renderComponent` on frontend doesn't try to hydrate SSR when SSR is explicitly disabled.

--- a/packages/ap-frontend/alliance_platform/frontend/templatetags/react.py
+++ b/packages/ap-frontend/alliance_platform/frontend/templatetags/react.py
@@ -930,7 +930,7 @@ class ComponentNode(template.Node, BundlerAsset):
             props["children"] = ChildrenList(props["children"])
         self.container_tag = container_tag
         self.container_props = container_props or {}
-        self.ssr_disabled = ssr_disabled
+        self.ssr_disabled = ssr_disabled or not get_bundler().is_ssr_enabled()
         self.source = source
         self.props = props
         self.target_var = target_var


### PR DESCRIPTION
Previous changes allowed disabling SSR explicitly, but frontend `renderComponent` `shouldHydrate` option could still be true. Fix so this is always false when ssr is disabled.