### PR TITLE
Fix/form input handling improvements

### DIFF
--- a/.changeset/fresh-crabs-unite.md
+++ b/.changeset/fresh-crabs-unite.md
@@ -1,0 +1,5 @@
+---
+"alliance-platform-frontend": patch
+---
+
+Add `LabeledInput` template tag to `alliance_ui`

--- a/.changeset/funny-carpets-obey.md
+++ b/.changeset/funny-carpets-obey.md
@@ -1,0 +1,5 @@
+---
+"alliance-platform-frontend": patch
+---
+
+Default `extra_widget_props` to empty dict if not set. This avoids need for widget templates to check for existence; it can rely on it being set so long as `FORM_RENDERED` is set. This allows widget templates to work when used with or without the `form_input` tag.

--- a/.changeset/great-needles-boil.md
+++ b/.changeset/great-needles-boil.md
@@ -1,0 +1,5 @@
+---
+"alliance-platform-frontend": patch
+---
+
+`form_input` can now be used within `{% component %}` tags

--- a/.changeset/mighty-peas-cheer.md
+++ b/.changeset/mighty-peas-cheer.md
@@ -1,0 +1,5 @@
+---
+"alliance-platform-frontend": patch
+---
+
+Add `non_standard_widget` option to `form_input`. This will wrap the widget in a `LabeledInput` to display label, help text, validation errors etc in same format as other alliance_ui widgets

--- a/packages/ap-frontend/alliance_platform/frontend/alliance_ui/labeled_input.py
+++ b/packages/ap-frontend/alliance_platform/frontend/alliance_ui/labeled_input.py
@@ -1,0 +1,36 @@
+from django import template
+from django.template import Context
+from django.template import Library
+
+from ..templatetags.react import ComponentNode
+from ..templatetags.react import ComponentProps
+from ..templatetags.react import parse_component_tag
+from .utils import get_module_import_source
+
+
+class LabeledInputNode(ComponentNode):
+    def resolve_props(self, context: Context) -> ComponentProps:
+        values = super().resolve_props(context)
+        # LabeledInput doesn't support validationState, it only handles ``isInvalid`` so convert it here
+        validation_state = values.pop("validationState", "")
+        if validation_state == "invalid":
+            values.update({"isInvalid": True})
+        return values
+
+
+def labeled_input(parser: template.base.Parser, token: template.base.Token):
+    """
+    Render ``LabeledInput``.
+
+    For compatability with ``form_input`` it will convert ``validationState="invalid"`` into ``isInvalid=True``.
+    """
+    return parse_component_tag(
+        parser,
+        token,
+        asset_source=get_module_import_source("@alliancesoftware/ui", "LabeledInput", False, parser.origin),
+        node_class=LabeledInputNode,
+    )
+
+
+def register_labeled_input(register: Library):
+    register.tag("LabeledInput")(labeled_input)

--- a/packages/ap-frontend/alliance_platform/frontend/forms/renderers.py
+++ b/packages/ap-frontend/alliance_platform/frontend/forms/renderers.py
@@ -38,7 +38,7 @@ class FormInputContextRenderer(TemplatesSetting):
                 extra_context[NestedComponentPropAccumulator.context_key] = accumulator
             # setting a default means templates can assume the value always exists - makes
             # usage with merge_props etc easier
-            if "core_ui_props" not in extra_context:
-                extra_context["core_ui_props"] = {}
+            if "extra_widget_props" not in extra_context:
+                extra_context["extra_widget_props"] = {}
             context.update(extra_context)
         return super().render(template_name, context, request)

--- a/packages/ap-frontend/alliance_platform/frontend/forms/renderers.py
+++ b/packages/ap-frontend/alliance_platform/frontend/forms/renderers.py
@@ -25,8 +25,17 @@ class FormInputContextRenderer(TemplatesSetting):
     form_input_context_key = form_input_context_key
 
     def render(self, template_name, context, request=None):
+        from alliance_platform.frontend.templatetags.react import NestedComponentPropAccumulator
+
         if "widget" in context and "attrs" in context["widget"]:
+            # in order to support nested components, ``form_input`` will set the accumulator (which indicates
+            # that the widget is a nested component) in the widget.attrs. This renderer will pop it out and
+            # pass it through in the root ``context`` that is used by the widget template. This allows the
+            # ``component`` to detect that it is a nested component and handle accordingly.
+            accumulator = context["widget"]["attrs"].pop(NestedComponentPropAccumulator.context_key, None)
             extra_context = context["widget"]["attrs"].pop(form_input_context_key, {})
+            if accumulator:
+                extra_context[NestedComponentPropAccumulator.context_key] = accumulator
             # setting a default means templates can assume the value always exists - makes
             # usage with merge_props etc easier
             if "core_ui_props" not in extra_context:

--- a/packages/ap-frontend/alliance_platform/frontend/html_parser.py
+++ b/packages/ap-frontend/alliance_platform/frontend/html_parser.py
@@ -1,0 +1,256 @@
+from dataclasses import dataclass
+from dataclasses import field
+from html.parser import HTMLParser
+import re
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Union
+import warnings
+
+from alliance_platform.frontend.util import transform_attribute_names
+from django.template import Context
+from django.template import Node
+from django.template import NodeList
+from django.template import Origin
+
+if TYPE_CHECKING:
+    from alliance_platform.frontend.templatetags.react import ComponentNode
+
+# These are used to replace template Nodes in a string with placeholders. The resulting string can them be parsed as HTML,
+# and then the placeholders replaced with the original template nodes.
+_html_replacement_placeholder_prefix = "_______placeholder_____$"
+_html_replacement_placeholder_suffix = "$_"
+html_replacement_placeholder_template = (
+    _html_replacement_placeholder_prefix + "{0}" + _html_replacement_placeholder_suffix
+)
+
+
+@dataclass
+class Element:
+    name: str
+    attrs: dict
+
+
+@dataclass
+class HTMLElement:
+    tag: str
+    attributes: dict[str, str] = field(default_factory=dict)
+    children: list[Union["HTMLElement", str]] = field(default_factory=list)
+
+
+# Extracted from https://developer.mozilla.org/en-US/docs/Glossary/Void_element
+void_elements = [
+    "area",
+    "base",
+    "br",
+    "col",
+    "embed",
+    "hr",
+    "img",
+    "input",
+    "link",
+    "meta",
+    "param",
+    "source",
+    "track",
+    "wbr",
+]
+
+# Extracted from https://html.spec.whatwg.org/multipage/indices.html#attributes-3
+boolean_html_attributes = [
+    "allowfullscreen",
+    "async",
+    "autofocus",
+    "autoplay",
+    "checked",
+    "controls",
+    "default",
+    "defer",
+    "disabled",
+    "formnovalidate",
+    "inert",
+    "ismap",
+    "itemscope",
+    "multiple",
+    "muted",
+    "nomodule",
+    "novalidate",
+    "open",
+    "playsinline",
+    "readonly",
+    "required",
+    "reversed",
+    "selected",
+    "shadowrootdelegatesfocus",
+    "shadowrootclonable",
+    "shadowrootserializable",
+]
+
+
+class HtmlTreeParser(HTMLParser):
+    def __init__(self):
+        super().__init__(convert_charrefs=True)
+        # The root of the parsed tree. The tag is nonsense, but not used - it's just to make implementation easier. We
+        # just use it for ``children``
+        self.root = HTMLElement("Root")
+        # Stack to maintain hierarchy of elements
+        self.stack = [self.root]
+
+    def handle_starttag(self, tag, attrs):
+        element = HTMLElement(tag, {attr[0]: attr[1] for attr in attrs})
+        if self.stack:
+            self.stack[-1].children.append(element)
+        else:
+            self.root = element
+        self.stack.append(element)
+        # for void elements close them immediately
+        if tag in void_elements:
+            self.handle_endtag(tag)
+
+    def handle_endtag(self, tag):
+        if self.stack and self.stack[-1].tag == tag:
+            self.stack.pop()
+
+    def handle_data(self, data):
+        if data and self.stack:
+            self.stack[-1].children.append(data)
+
+
+def is_valid_html_attribute_name(attr_name):
+    # This isn't strictly accurate, but it's good enough for our purposes.
+    # https://html.spec.whatwg.org/multipage/syntax.html#attributes-2
+    pattern = r'^[^\s\/<>=\'"=]+$'
+    return bool(re.match(pattern, attr_name))
+
+
+class HtmlAttributeTemplateNodeList:
+    """A list of HTML attributes that may contain template nodes.
+
+    Take an HTML string like::
+
+    .. code-block:: html+django
+
+            <input {% if value %}{{ value }}{% endif %} {% include "attrs.html" }>
+
+    When this is parsed by ``convert_html_string`` the attributes cannot be resolved until the context is available.
+    This gives us some template nodes, in the above example an ``IfNode`` and ``IncludeNode``. At some point we
+    want to resolve this attributes using the context. This class is used to store this and resolve it later.
+    """
+
+    def __init__(self, attrs: list[Node | str], original_html: str, origin: Origin):
+        self.original_html = original_html
+        self.attrs = attrs
+        self.origin = origin
+
+    def resolve(self, context: Context) -> dict[str, str]:
+        attr_str = " ".join([prop.render(context) if isinstance(prop, Node) else prop for prop in self.attrs])
+        parser = HtmlTreeParser()
+        parser.feed(f"<div {attr_str}></div>")
+        tags = parser.root.children
+        if tags:
+            return transform_html_attributes(tags[0].attributes, self.original_html, self.origin)
+        return {}
+
+
+def convert_html_string(
+    html: str, origin: Origin, *, replacements: dict[str, Node] | None = None
+) -> list[Union["ComponentNode", str]]:
+    """
+    Given a string that may contain HTML, convert it to a tree of ``ComponentNode``s
+
+    Args:
+        html: The html string to convert
+        origin: The template origin
+        replacements: Any replacements to make in the HTML after conversion. The way this works is that a template NodeList
+            is processed into a string, with any template nodes replaced with placeholders. The string is converted to
+            a component tree, then any placeholders are replaced with the original template nodes.
+    Returns:
+
+    """
+    # NOTE: I tried lxml initially (with & without BeautifulSoup), and it was slower for our specific use case.
+    # In general, it's considered very fast, but we don't need most of its features and this simple parser was
+    # faster.
+    parser = HtmlTreeParser()
+    # Parse the HTML
+    parser.feed(html)
+
+    tags = parser.root.children
+
+    def handle_placeholders(content: str):
+        if not replacements:
+            return [content]
+        parts = content.split(_html_replacement_placeholder_prefix)
+        first = parts.pop(0)
+        if not parts:
+            return [first]
+        children: list[str | Node] = []
+        if first:
+            children.append(first)
+        for part in parts:
+            placeholder_id, extra = part.split(_html_replacement_placeholder_suffix)
+            children.append(replacements[placeholder_id])
+            if extra:
+                children.append(extra)
+        return children
+
+    def convert_attributes(attrs: dict[str, str | Any]):
+        html_attribute_template_nodes = []
+        transformed = {}
+        for key, value in attrs.items():
+            if not value:
+                html_attribute_template_nodes += handle_placeholders(key)
+            else:
+                parts = handle_placeholders(value)
+                transformed[key] = parts[0] if len(parts) == 1 else NodeList(parts)
+        return transform_html_attributes(transformed, html, origin), html_attribute_template_nodes
+
+    def convert_tree(tree):
+        from alliance_platform.frontend.templatetags.react import CommonComponentSource
+        from alliance_platform.frontend.templatetags.react import ComponentNode
+
+        children = []
+        for el in tree:
+            if isinstance(el, str):
+                parts = handle_placeholders(el)
+                children += parts
+            else:
+                attrs, html_attribute_template_nodes = convert_attributes(el.attributes)
+                children.append(
+                    ComponentNode(
+                        origin,
+                        CommonComponentSource(el.tag),
+                        {**attrs, "children": convert_tree(el.children)},
+                        html_attribute_template_nodes=HtmlAttributeTemplateNodeList(
+                            html_attribute_template_nodes, html, origin
+                        ),
+                    )
+                )
+        return children
+
+    return convert_tree(tags)
+
+
+def transform_html_attributes(attrs: dict[str, str | None], original_html: str, origin: Origin):
+    """Transform the attributes of an HTML tag into the final form we want
+
+    This does the following:
+    - If any ``value`` is ``None``, set it to ``True`` if it's a boolean html attribute otherwise empty string
+    - If any key is invalid, remove it and warn
+    - Transform the attribute names to match what React expects
+    """
+
+    bad_keys: list[str] = []
+    final_attrs = {}
+    for key, value in attrs.items():
+        if not is_valid_html_attribute_name(key):
+            bad_keys.append(key)
+        elif value is None:
+            # for boolean attributes set it to ``True``, otherwise empty string
+            final_attrs[key] = True if key in boolean_html_attributes else ""
+        else:
+            final_attrs[key] = value
+    if bad_keys:
+        warnings.warn(
+            f"{origin} contained invalid HTML in '{original_html}'. The following parts were removed from tag: {', '.join(bad_keys)}"
+        )
+    return transform_attribute_names(final_attrs)

--- a/packages/ap-frontend/alliance_platform/frontend/html_parser.py
+++ b/packages/ap-frontend/alliance_platform/frontend/html_parser.py
@@ -4,7 +4,6 @@ from html.parser import HTMLParser
 import re
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Union
 import warnings
 
 from alliance_platform.frontend.util import transform_attribute_names
@@ -35,7 +34,7 @@ class Element:
 class HTMLElement:
     tag: str
     attributes: dict[str, str] = field(default_factory=dict)
-    children: list[Union["HTMLElement", str]] = field(default_factory=list)
+    children: list["HTMLElement" | str] = field(default_factory=list)
 
 
 # Extracted from https://developer.mozilla.org/en-US/docs/Glossary/Void_element
@@ -154,7 +153,7 @@ class HtmlAttributeTemplateNodeList:
 
 def convert_html_string(
     html: str, origin: Origin, *, replacements: dict[str, Node] | None = None
-) -> list[Union["ComponentNode", str]]:
+) -> list["ComponentNode" | str]:
     """
     Given a string that may contain HTML, convert it to a tree of ``ComponentNode``s
 

--- a/packages/ap-frontend/alliance_platform/frontend/management/commands/extract_frontend_assets.py
+++ b/packages/ap-frontend/alliance_platform/frontend/management/commands/extract_frontend_assets.py
@@ -19,6 +19,8 @@ from ...bundler import get_bundler
 from ...bundler.context import BundlerAssetContext
 from ...settings import ap_frontend_settings
 
+frontend_templates_dir = Path(__file__).parent.parent.parent / "templates"
+
 
 @lru_cache
 def get_all_templates_files() -> list[Path]:
@@ -40,7 +42,9 @@ def get_all_templates_files() -> list[Path]:
             elif str(dir).startswith(str(excl)):
                 should_exclude = True
 
-        if should_exclude:
+        # always include the frontend templates dir even if would otherwise
+        # be excluded
+        if should_exclude and dir != frontend_templates_dir:
             continue
         files.extend(x for x in Path(dir).glob("**/*.html") if x)
     return files

--- a/packages/ap-frontend/alliance_platform/frontend/templates/alliance_platform/ui/labeled_input_base.html
+++ b/packages/ap-frontend/alliance_platform/frontend/templates/alliance_platform/ui/labeled_input_base.html
@@ -1,0 +1,6 @@
+{% load alliance_ui %}
+{% load react %}
+
+{% LabeledInput props=extra_widget_props %}
+  {% block input %}{% endblock %}
+{% endLabeledInput %}

--- a/packages/ap-frontend/alliance_platform/frontend/templatetags/alliance_ui.py
+++ b/packages/ap-frontend/alliance_platform/frontend/templatetags/alliance_ui.py
@@ -13,6 +13,7 @@ from ..alliance_ui.button import register_button
 from ..alliance_ui.date_picker import register_date_picker
 from ..alliance_ui.icon import register_icon
 from ..alliance_ui.inline_alert import register_inline_alert
+from ..alliance_ui.labeled_input import register_labeled_input
 from ..alliance_ui.menubar import register_menubar
 from ..alliance_ui.misc import register_misc
 from ..alliance_ui.pagination import register_pagination
@@ -32,6 +33,7 @@ register_inline_alert(register)
 register_icon(register)
 register_date_picker(register)
 register_time_input(register)
+register_labeled_input(register)
 
 
 class NamedUrlDeferredProp(DeferredProp):

--- a/packages/ap-frontend/alliance_platform/frontend/templatetags/form.py
+++ b/packages/ap-frontend/alliance_platform/frontend/templatetags/form.py
@@ -9,13 +9,20 @@ from allianceutils.template import resolve
 from django import template
 from django.forms import BaseForm
 from django.forms import BoundField
+from django.template import Context
+from django.template import Node
 from django.template import NodeList
 from django.template import Origin
 from django.template import TemplateSyntaxError
 from django.template.base import UNKNOWN_SOURCE
 from django.template.base import FilterExpression
 
+from ..alliance_ui.labeled_input import LabeledInputNode
+from ..alliance_ui.utils import get_module_import_source
 from ..forms.renderers import FormInputContextRenderer
+from .react import ComponentNode
+from .react import NestedComponentProp
+from .react import NestedComponentPropAccumulator
 from .react import convert_html_string
 
 register = template.Library()
@@ -41,6 +48,7 @@ class FormInputNode(template.Node):
         label=_NOT_PROVIDED,
         is_required=None,
         show_valid_state=True,
+        non_standard_widget=False,
         **extra_attrs,
     ):
         self.origin = origin or Origin(UNKNOWN_SOURCE)
@@ -50,6 +58,7 @@ class FormInputNode(template.Node):
         self.label = label
         self.required = is_required
         self.extra_attrs = extra_attrs or {}
+        self.non_standard_widget = non_standard_widget
 
     def render(self, context: template.Context):
         field: BoundField = self.field.resolve(context)
@@ -87,7 +96,159 @@ class FormInputNode(template.Node):
                 },
             }
             form_context.mark_processed(field.name)
+            if self.non_standard_widget:
+                node = LabeledInputNode(
+                    self.origin,
+                    get_module_import_source("@alliancesoftware/ui", "LabeledInput", False, self.origin),
+                    {
+                        **extra_attrs[field.form.renderer.form_input_context_key]["extra_widget_props"],
+                        "children": [],
+                    },
+                )
+                node.props.update({"children": NodeList([NestedComponentFormWidgetNode(field, self.origin)])})
+                return node.render(context)
+            if NestedComponentPropAccumulator.context_key in context:
+                # If this is used within another React component, we need to defer rendering of the widget so that
+                # it has access to the NestedComponentPropAccumulator
+                return NestedComponentFormWidgetNode(field, self.origin, extra_attrs).render(context)
         return field.as_widget(attrs=extra_attrs)  # type: ignore[arg-type] # dict type in form says on str|bool but other types seem to work fine
+
+
+def _replace_nodes_with_str(items: list[str | ComponentNode], separator: str):
+    replacements: dict[str, ComponentNode] = {}
+    final_items: list[str] = []
+    for item in items:
+        if isinstance(item, ComponentNode):
+            placeholder = f"__form_widget_placeholder({len(replacements)})__"
+            replacements[placeholder] = item
+            final_items.append(placeholder)
+        else:
+            final_items.append(item)
+    return separator.join(final_items), replacements
+
+
+class NestedComponentFormWidgetNode(Node):
+    field: BoundField
+    origin: Origin
+    attrs: dict
+
+    def __init__(self, field: BoundField, origin: Origin, attrs: dict | None = None):
+        self.field = field
+        self.origin = origin
+        self.attrs = attrs or {}
+
+    def render(self, context: Context):
+        """
+        This is a bit of a hack, so some explanation is needed.
+
+        The problem we are solving is that widgets are rendered as standalone templates. This means that
+        the contents is not treated as a component child, even though in this case we are treating it as such.
+
+        temp_accumulator is a temporary accumulator that is used to collect the children of the widget as
+        it is rendered. Note that we have to pass this through under ``attrs`` to the ``as_widget`` method which
+        makes it appear under ``widget.attrs`` in the final widget template context. This needs to be at the top
+        level however, so we rely on ``FormInputContextRenderer`` to pop this value and insert it into the context.
+        This is the only way to manipulate the final context a widget template gets rendered with, otherwise you
+        can only change ``widget.attrs``. ``FormInputContextRenderer`` is checked in ``FormInputNode`` so it's
+        guaranteed to be used if this code path gets executed.
+
+        This is necessary because the widget may contain nested components that need to be
+        rendered within the context of the parent component (i.e. we don't want the <script> tags etc, we
+        want it to get added to the ``accumulator`` above.
+
+        However, there could be other HTML mixed in with those components so we have to do it in two passes.
+        The first pass renders the widgets, collects any nested components and replaces them with placeholders.
+        The second passes the first output through ``convert_html_string`` to generate a list of components (where
+        HTML tags are encountered), or strings otherwise.
+
+        Take for example this template. It has a mixture of component nodes that will be handled in first pass,
+        HTML handled in second pass, and plain strings that require no transformation:
+
+            {% component "@alliancesoftware/ui" "TextInput" props=widget.attrs %}{% endcomponent %}
+            Plain text <strong>Nested HTML</strong> More text <span>Extra</span>
+            {% component "i" %}Another Component{% endcomponent %}
+            End
+
+        ``widget_html`` will be:
+
+            __NestedComponentPropAccumulator__prop__0
+            Plain text <strong>Nested HTML</strong> More text <span>Extra</span>
+            __NestedComponentPropAccumulator__prop__1
+            End
+
+        ``convert_html_string`` will return:
+
+            [
+              '__NestedComponentPropAccumulator__prop__0\nPlain text ',
+              ComponentNode(CommonComponentSource(name='strong'), {'children': ['Nested HTML']}),
+              ' More text ',
+              ComponentNode(CommonComponentSource(name='span'), {'children': ['Extra']}),
+              '\n__NestedComponentPropAccumulator__prop__1\nEnd'
+            ]
+
+        Next we replace any `ComponentNode` with a placeholder (__form_widget_placeholder(0)__) using ``_replace_nodes_with_str``
+        which generates a string like:
+
+            __NestedComponentPropAccumulator__prop__0
+            Plain text __form_widget_placeholder(0)__ More text __form_widget_placeholder(1)__
+            __NestedComponentPropAccumulator__prop__1
+            End
+
+        This gets passed through ``temp_accumulator.apply`` which will replace any of the placeholders from first
+        pass ("__NestedComponentPropAccumulator__prop__0" in the example). This results in:
+
+            [
+                NestedComponentProp(ImportComponentSource(TextInput), ComponentProps({..})),
+                '\nPlain text __form_widget_placeholder(0)__ More text __form_widget_placeholder(1)__\n',
+                 NestedComponentProp(CommonComponentSource(name='i'), ComponentProps({'children': 'Another Component'})),
+                 '\nEnd'
+            ]
+
+        Finally, we iterate over this list. If a `NestedComponentProp` is encountered, it's added as a child to the
+        original parent component with ``accumulator.add`` (this returns a string placeholder). If a string is
+        encountered we have to replace any of the __form_widget_placeholder(i)__ placeholders. We do this by getting
+        the original component for that placeholder, add it with ``accumulator.add`` and use the placeholder returned
+        in place of the original. This is repeated until all placeholders are replaced. This gives us a final
+        string like:
+
+            __NestedComponentPropAccumulator__prop__0
+            Plain text __NestedComponentPropAccumulator__prop__1 More text __NestedComponentPropAccumulator__prop__2
+            __NestedComponentPropAccumulator__prop__3
+            End
+
+        This is what we return, and the parent component will replace any of the remaining placeholders as part of
+        the normal ``ComponentNode`` rendering.
+        """
+
+        # This is the parent component accumulator we are rendered within. This ``render`` method is being called
+        # from within ``ComponentNode`` within an active NestedComponentPropAccumulator context.
+        accumulator = context.get(NestedComponentPropAccumulator.context_key)
+        if not accumulator:
+            raise ValueError("Unexpected: NestedComponentPropAccumulator not found in context")
+
+        with NestedComponentPropAccumulator(context, accumulator.origin_node) as temp_accumulator:
+            widget_html = self.field.as_widget(
+                attrs={**self.attrs, NestedComponentPropAccumulator.context_key: temp_accumulator}
+            )
+            final = []
+            # if this string appears in the string then it's going to be lost in the final output, but
+            # considering they aren't visible characters it likely doesn't matter.
+            # Zero-width Space + Information Separator Four
+            separator = "\u200b\u001c"
+            combined_str, replacements = _replace_nodes_with_str(
+                convert_html_string(widget_html, self.origin), separator
+            )
+            for item in temp_accumulator.apply(combined_str):
+                if isinstance(item, str):
+                    for part in item.split(separator):
+                        if part in replacements:
+                            prop = NestedComponentProp(replacements[part], accumulator.origin_node, context)
+                            final.append(accumulator.add(prop))
+                        else:
+                            final.append(part)
+                else:
+                    final.append(accumulator.add(item))
+            return "".join(final)
 
 
 @register.tag("form_input")

--- a/packages/ap-frontend/alliance_platform/frontend/templatetags/react.py
+++ b/packages/ap-frontend/alliance_platform/frontend/templatetags/react.py
@@ -1323,6 +1323,24 @@ class HTMLElement:
     children: list[Union["HTMLElement", str]] = field(default_factory=list)
 
 
+void_elements = [
+    "area",
+    "base",
+    "br",
+    "col",
+    "embed",
+    "hr",
+    "img",
+    "input",
+    "link",
+    "meta",
+    "param",
+    "source",
+    "track",
+    "wbr",
+]
+
+
 class HtmlTreeParser(HTMLParser):
     def __init__(self):
         super().__init__(convert_charrefs=True)
@@ -1339,6 +1357,9 @@ class HtmlTreeParser(HTMLParser):
         else:
             self.root = element
         self.stack.append(element)
+        # for void elements close them immediately
+        if tag in void_elements:
+            self.handle_endtag(tag)
 
     def handle_endtag(self, tag):
         if self.stack and self.stack[-1].tag == tag:

--- a/packages/ap-frontend/alliance_platform/frontend/templatetags/react.py
+++ b/packages/ap-frontend/alliance_platform/frontend/templatetags/react.py
@@ -348,6 +348,11 @@ class NestedComponentPropAccumulator:
         This returns a string that should be rendered in the components place. It will then be
         handled in ``apply``.
         """
+        if not isinstance(prop, NestedComponentProp):
+            raise ValueError(
+                "must be a NestedComponentProp; if you are passing ComponentNode wrap it in ComponentProp first"
+            )
+
         key = f"{self.context_key}__prop__{len(self.props)}"
         self.props[key] = prop
         return key

--- a/packages/ap-frontend/docs/alliance_ui.rst
+++ b/packages/ap-frontend/docs/alliance_ui.rst
@@ -273,6 +273,47 @@ from the Alliance UI React library with the specified props.
 
     {% InlineAlert intent="success" %}Changes saved successfully{% endInlineAlert %}
 
+
+.. templatetag:: LabeledInput
+
+``LabeledInput``
+----------------
+
+Render an `LabeledInput <https://main--64894ae38875dcf46367336f.chromatic.com/?path=/docs/ui-labeledinput--docs>`_ component
+from the Alliance UI React library with the specified props.
+
+This can be useful with custom widgets that get rendered with :ttag:`form_input` where you want standard rendering
+of label, help text, validation, required indicator etc.
+
+.. code-block:: html+django
+
+    {% load alliance_ui %}
+
+    {# this is in your widget template. extra_widget_props come from `form_input` #}
+    {% LabeledInput props=extra_widget_props %}
+       {# render your widget here. validation, help text and label will be handled for you. %}
+       <input />
+    {% endLabeledInput %}
+
+Alternatively, you can extend the ``alliance_platform/ui/labeled_input_base.html`` template
+as a base and fill in the ``input`` block with the relevant HTML:
+
+.. code-block:: html+django
+
+    {% extends "alliance_platform/ui/labeled_input_base.html" %}
+
+    {% block input %}
+      <input type="{{ widget.type }}" name="{{ widget.name }}"{% if widget.value != None %} value="{{ widget.value|stringformat:'s' }}"{% endif %}>
+    {% endblock %}
+
+Finally, if you want to wrap a single instance of a widget without changing the template you can use
+the ``non_standard_widget=True`` option to :ttag:`form_input`. This will render the widget as normal,
+but wrap it in a ``LabeledInput`` component.
+
+    .. code-block:: html+django
+
+    {% form_input field non_standard_widget=True %}
+
 .. templatetag:: Menubar
 
 ``Menubar``

--- a/packages/ap-frontend/test_alliance_platform_frontend/templates/react_test_templates/attrs.html
+++ b/packages/ap-frontend/test_alliance_platform_frontend/templates/react_test_templates/attrs.html
@@ -1,0 +1,1 @@
+id="input" {% if value %}value={{ value }}{% endif %} class="input"

--- a/packages/ap-frontend/tests/test_bundler_templatetags.py
+++ b/packages/ap-frontend/tests/test_bundler_templatetags.py
@@ -956,3 +956,60 @@ class TestComponentTemplateTagOutput(SimpleTestCase):
             {% component "div" %}<input id="input" /> middle <span>end</span>{% endcomponent %}""",
             """<div><input id="input"/> middle <span>end</span></div>""",
         )
+
+    def test_html_attribute_if_condition(self):
+        self.assertComponentEqual(
+            """
+            {% component "div" %}<input id="input" {% if value %}value={{value}}{% endif %}>{% endcomponent %}""",
+            """<div><input id="input" /></div>""",
+        )
+
+        self.assertComponentEqual(
+            """
+            {% component "div" %}<input id="input" {% if value %}value={{value}}{% endif %}>{% endcomponent %}""",
+            """<div><input id="input" value="yes" /></div>""",
+            value="yes",
+        )
+
+    def test_html_attribute_include(self):
+        """void tags like 'input' should be handled with or without self closing"""
+        self.assertComponentEqual(
+            """
+            {% component "div" %}<input {% include "react_test_templates/attrs.html" %}>{% endcomponent %}""",
+            """<div><input id="input" className="input" /></div>""",
+        )
+
+        self.assertComponentEqual(
+            """
+            {% component "div" %}<input {% include "react_test_templates/attrs.html" %}>{% endcomponent %}""",
+            """<div><input id="input" value="yes" className="input" /></div>""",
+            value="yes",
+        )
+
+    def test_html_attribute_no_value(self):
+        self.assertComponentEqual(
+            """
+            {% component "div" %}<input download>{% endcomponent %}""",
+            """<div><input download=""/></div>""",
+        )
+
+        self.assertComponentEqual(
+            """
+            {% component "div" %}<input disabled>{% endcomponent %}""",
+            """<div><input disabled={true} /></div>""",
+        )
+
+    def test_html_bad_attributes(self):
+        with self.assertWarnsRegex(Warning, "contained invalid HTML"):
+            self.assertComponentEqual(
+                """
+                {% component "div" %}<input ">{% endcomponent %}""",
+                """<div><input /></div>""",
+            )
+
+        with self.assertWarnsRegex(Warning, "contained invalid HTML"):
+            self.assertComponentEqual(
+                """
+                {% component "div" %}<input "=5 id="test">{% endcomponent %}""",
+                """<div><input id="test" /></div>""",
+            )

--- a/packages/ap-frontend/tests/test_bundler_templatetags.py
+++ b/packages/ap-frontend/tests/test_bundler_templatetags.py
@@ -942,3 +942,17 @@ class TestComponentTemplateTagOutput(SimpleTestCase):
             """<div><a href="/test/">Test</a></div>""",
             url="/test/",
         )
+
+    def test_void_tags(self):
+        """void tags like 'input' should be handled with or without self closing"""
+        self.assertComponentEqual(
+            """
+            {% component "div" %}<input id="input"> middle <span>end</span>{% endcomponent %}""",
+            """<div><input id="input"/> middle <span>end</span></div>""",
+        )
+
+        self.assertComponentEqual(
+            """
+            {% component "div" %}<input id="input" /> middle <span>end</span>{% endcomponent %}""",
+            """<div><input id="input"/> middle <span>end</span></div>""",
+        )


### PR DESCRIPTION
Main improvements here are

- `form_input` works within components now. Previously there was a limitation that this wold not work.
- Improve `form_input` docs, suggesting how to integrate with non-alliance ui widgets
- Add `LabeledInput` to make laying out non-alliance ui widgets consistently easy
- Add `non_standard_widget` option to `form_input` 
- templates no longer need to check if `extra_widget_props` exist - it can be assumed it always does (defaults to empty dict). previously, if using a alliance-ui widget without the `form_input` tag you had to handle the case where it didn't exist manually.
- Fixes to HTML parsing to make it more robust 

Main doc changes: [LabeledInput](https://alliance-platform--32.org.readthedocs.build/projects/frontend/32/alliance_ui.html#labeledinput), [form_input](https://alliance-platform--32.org.readthedocs.build/projects/frontend/32/templatetags.html#form-input)

Probably easiest to review commit by commit