### PR TITLE
fix: embed css for a component when nested

### DIFF
--- a/.changeset/afraid-llamas-change.md
+++ b/.changeset/afraid-llamas-change.md
@@ -1,0 +1,5 @@
+---
+"alliance-platform-frontend": patch
+---
+
+Fix issue where associated CSS for a nested component wasn't being embedded


### PR DESCRIPTION
Fixes a bug where a component nested within another that had dependent CSS, the CSS <style> tag wasn't being included in output 