### PR TITLE
Prop handler get bundler paths, eliminate need for re-exports.tsx

### DIFF
--- a/.changeset/clever-timers-watch.md
+++ b/.changeset/clever-timers-watch.md
@@ -1,0 +1,5 @@
+---
+"alliance-platform-frontend": patch
+---
+
+Add classmethod `get_paths_for_bundling` to `ComponentProp`. This allows a handler to specify what dependencies they have that need to be included by the bundler. Previously this was done manually using `FrontendAssetRegistry"

--- a/.changeset/fluffy-walls-heal.md
+++ b/.changeset/fluffy-walls-heal.md
@@ -1,0 +1,5 @@
+---
+"alliance-platform-frontend": patch
+---
+
+TimeProp, DateTimeProp, DateProp, ZonedDateTimeProp no long use the frontend/src/re-exports.tsx file, and instead directly reference @internationalized/date

--- a/.changeset/silver-dolls-bake.md
+++ b/.changeset/silver-dolls-bake.md
@@ -1,0 +1,5 @@
+---
+"alliance-platform-frontend": patch
+---
+
+alliance_ui tag `{% Fragment %}` no longer imports from re-exports and instead uses "react" directly. This removes the need for the frontend/src/re-exports file in projects and can be removed.

--- a/packages/ap-frontend/alliance_platform/frontend/alliance_ui/misc.py
+++ b/packages/ap-frontend/alliance_platform/frontend/alliance_ui/misc.py
@@ -14,9 +14,9 @@ def fragment_component(parser: template.base.Parser, token: template.base.Token)
     bundler = get_bundler()
     resolver_context = ResolveContext(bundler.root_dir, parser.origin.name if parser.origin else None)
     source_path = get_bundler().resolve_path(
-        "re-exports", resolver_context, resolve_extensions=[".ts", ".tsx", ".js"]
+        "/node_modules/react", resolver_context, resolve_extensions=[".ts", ".tsx", ".js"]
     )
-    asset_source = ImportComponentSource(source_path, "Fragment", False)
+    asset_source = ImportComponentSource(source_path, "React", True, "Fragment")
     return parse_component_tag(parser, token, asset_source=asset_source)
 
 

--- a/packages/ap-frontend/alliance_platform/frontend/bundler/vite.py
+++ b/packages/ap-frontend/alliance_platform/frontend/bundler/vite.py
@@ -245,6 +245,16 @@ class ViteManifest:
             # will resolve to components/table/index.tsx
             if key.stem == "index":
                 entries[key.parent] = entries[key]
+
+            # This "unresolvedPath" is an extension we provide with a custom plugin. This stores the unresolved path
+            # (i.e. the path you might use in a template, e.g. "@internationalized/date") so that we can map it to
+            # the resolved path (e.g. "node_modules/@internationalized/date/dist/import.mjs"). The resolved path is
+            # what the key is in the manifest.json, which most of the time matches, but sometimes doesn't. We handle
+            # the most common case above - which is the resolved path is /package-name/index.js - but this is customisable
+            # by setting `module` or `exports` in the package.json.
+            if value.get("unresolvedPath") and value.get("unresolvedPath") != str(key):
+                unresolved_path = Path(value.get("unresolvedPath"))
+                entries[unresolved_path] = entries[key]
         self.entries = entries
         for entry in self.entries.values():
             entry.collect_dependencies()

--- a/packages/ap-frontend/alliance_platform/frontend/bundler/vite.py
+++ b/packages/ap-frontend/alliance_platform/frontend/bundler/vite.py
@@ -252,6 +252,9 @@ class ViteManifest:
             # what the key is in the manifest.json, which most of the time matches, but sometimes doesn't. We handle
             # the most common case above - which is the resolved path is /package-name/index.js - but this is customisable
             # by setting `module` or `exports` in the package.json.
+            # See https://gitlab.internal.alliancesoftware.com.au/alliance/template-django/-/merge_requests/495/diffs?commit_id=b83920cbda5d6e26445e19ea0b740a9201b488f8
+            # for where this plugin was introduced
+            # TODO: We will migrate this to a separate package at some point, clean up the above reference when done
             if value.get("unresolvedPath") and value.get("unresolvedPath") != str(key):
                 unresolved_path = Path(value.get("unresolvedPath"))
                 entries[unresolved_path] = entries[key]

--- a/packages/ap-frontend/alliance_platform/frontend/prop_handlers.py
+++ b/packages/ap-frontend/alliance_platform/frontend/prop_handlers.py
@@ -83,7 +83,7 @@ class ComponentProp(SSRCustomFormatSerializable, CodeGeneratorNode):
     def get_paths_for_bundling(cls):
         """Return any paths that need to be included in bundling to make use of this prop
 
-        Note that if this is specified, the paths will _always_ be included in the bundler even if the props
+        Note that if this is specified, the paths will _always_ be included in the bundler even if the prop
         is not used.
 
         Returns:

--- a/packages/ap-frontend/alliance_platform/frontend/prop_handlers.py
+++ b/packages/ap-frontend/alliance_platform/frontend/prop_handlers.py
@@ -15,6 +15,7 @@ from django.utils.timezone import is_aware
 
 from .bundler.ssr import SSRCustomFormatSerializable
 from .bundler.ssr import SSRSerializerContext
+from .settings import ap_frontend_settings
 
 if TYPE_CHECKING:
     from .templatetags.react import ComponentNode
@@ -109,13 +110,17 @@ class DateProp(ComponentProp):
 
     def generate_code(self, generator: ComponentSourceCodeGenerator):
         calendar_date = generator.resolve_prop_import(
-            "frontend/src/re-exports.tsx", ImportSpecifier("CalendarDate")
+            "node_modules/@internationalized/date", ImportSpecifier("CalendarDate")
         )
         return NewExpression(calendar_date, self.js_args)
 
     @classmethod
     def should_apply(cls, value: Any, node: ComponentNode, context: Context):
         return isinstance(value, datetime.date) and not isinstance(value, datetime.datetime)
+
+    @classmethod
+    def get_paths_for_bundling(cls):
+        return [ap_frontend_settings.NODE_MODULES_DIR / "@internationalized/date"]
 
 
 class DateTimeProp(ComponentProp):
@@ -144,7 +149,7 @@ class DateTimeProp(ComponentProp):
 
     def generate_code(self, generator: ComponentSourceCodeGenerator):
         calendar_date = generator.resolve_prop_import(
-            "frontend/src/re-exports.tsx", ImportSpecifier("CalendarDateTime")
+            "node_modules/@internationalized/date", ImportSpecifier("CalendarDateTime")
         )
         return NewExpression(
             calendar_date,
@@ -154,6 +159,10 @@ class DateTimeProp(ComponentProp):
     @classmethod
     def should_apply(cls, value: Any, node: ComponentNode, context: Context):
         return isinstance(value, datetime.datetime) and not is_aware(value)
+
+    @classmethod
+    def get_paths_for_bundling(cls):
+        return [ap_frontend_settings.NODE_MODULES_DIR / "@internationalized/date"]
 
 
 class ZonedDateTimeProp(ComponentProp):
@@ -189,7 +198,7 @@ class ZonedDateTimeProp(ComponentProp):
 
     def generate_code(self, generator: ComponentSourceCodeGenerator):
         calendar_date = generator.resolve_prop_import(
-            "frontend/src/re-exports.tsx", ImportSpecifier("ZonedDateTime")
+            "node_modules/@internationalized/date", ImportSpecifier("ZonedDateTime")
         )
         return NewExpression(
             calendar_date,
@@ -199,6 +208,10 @@ class ZonedDateTimeProp(ComponentProp):
     @classmethod
     def should_apply(cls, value: Any, node: ComponentNode, context: Context):
         return isinstance(value, datetime.datetime) and is_aware(value)
+
+    @classmethod
+    def get_paths_for_bundling(cls):
+        return [ap_frontend_settings.NODE_MODULES_DIR / "@internationalized/date"]
 
 
 class TimeProp(ComponentProp):
@@ -218,12 +231,18 @@ class TimeProp(ComponentProp):
         return self.js_args
 
     def generate_code(self, generator: ComponentSourceCodeGenerator):
-        calendar_date = generator.resolve_prop_import("frontend/src/re-exports.tsx", ImportSpecifier("Time"))
+        calendar_date = generator.resolve_prop_import(
+            "node_modules/@internationalized/date", ImportSpecifier("Time")
+        )
         return NewExpression(calendar_date, self.js_args)
 
     @classmethod
     def should_apply(cls, value: Any, node: ComponentNode, context: Context):
         return isinstance(value, datetime.time)
+
+    @classmethod
+    def get_paths_for_bundling(cls):
+        return [ap_frontend_settings.NODE_MODULES_DIR / "@internationalized/date"]
 
 
 class SetProp(ComponentProp):

--- a/packages/ap-frontend/alliance_platform/frontend/prop_handlers.py
+++ b/packages/ap-frontend/alliance_platform/frontend/prop_handlers.py
@@ -62,12 +62,33 @@ class ComponentProp(SSRCustomFormatSerializable, CodeGeneratorNode):
 
     @classmethod
     def should_apply(cls, value: Any, node: ComponentNode, context: Context):
-        """Return ``True`` if this prop handler should be used for the given value."""
+        """Return ``True`` if this prop handler should be used for the given value.
+
+        Args:
+            value: The value in question
+            node: The :class:`~alliance_platform.frontend.templatetags.react.ComponentNode` this is being used in
+            context: The current template context
+
+        Returns:
+            ``True`` if this prop handler should be used for the given value.
+        """
         raise NotImplementedError(f"should_apply not implemented for {cls.__name__}")
 
     def __init__(self, value: Any, node: ComponentNode, context: Context):
         """Intentionally blank; each implementation can handle this differently."""
         pass
+
+    @classmethod
+    def get_paths_for_bundling(cls):
+        """Return any paths that need to be included in bundling to make use of this prop
+
+        Note that if this is specified, the paths will _always_ be included in the bundler even if the props
+        is not used.
+
+        Returns:
+            A list of :class:`~pathlib.Path` instances that need to be included in the bundling process.
+        """
+        return []
 
 
 class DateProp(ComponentProp):

--- a/packages/ap-frontend/alliance_platform/frontend/settings.py
+++ b/packages/ap-frontend/alliance_platform/frontend/settings.py
@@ -134,6 +134,8 @@ class AlliancePlatformFrontendSettings(AlliancePlatformSettingsBase):
 
         # lock registry to make sure assets aren't added after startup that would be missed by
         # extract_frontend_assets
+        for prop_handler in self.REACT_PROP_HANDLERS:
+            self.FRONTEND_ASSET_REGISTRY.add_asset(*prop_handler.get_paths_for_bundling())
         self.FRONTEND_ASSET_REGISTRY.lock()
 
 


### PR DESCRIPTION
- Add classmethod `get_paths_for_bundling` to `ComponentProp`. This allows a handler to specify what dependencies they have that need to be included by the bundler. Previously this was done manually using `FrontendAssetRegistry"
- Update existing prop handlers to make use of this
- Remove all usages of "re-exports.tsx", which was a file that had to exist in the project and just re-exported dependencies from third party libraries. This was to work around some issues in the early Vite integration but is no longer required; we just import directly now.


To make full use of these changes see [this MR](https://gitlab.internal.alliancesoftware.com.au/alliance/template-django/-/merge_requests/495) for required changes - mainly the `modifyManifestPlugin`.