### PR TITLE
fix: handle asset reg locking in test cases

### DIFF
--- a/.changeset/great-moons-search.md
+++ b/.changeset/great-moons-search.md
@@ -1,0 +1,5 @@
+---
+"alliance-platform-frontend": patch
+---
+
+Handle error with FrontendAssetRegistry that could occur in test cases when @modify_settings is used

--- a/packages/ap-frontend/alliance_platform/frontend/settings.py
+++ b/packages/ap-frontend/alliance_platform/frontend/settings.py
@@ -132,6 +132,9 @@ class AlliancePlatformFrontendSettings(AlliancePlatformSettingsBase):
     def check_settings(self):
         # TODO: Implement checks on required settings
 
+        # Make sure registry is unlocked; this can happen in tests where settings are reloaded
+        # Just modify property directly, it's for internal use only - don't want 'unlock' part of the API
+        self.FRONTEND_ASSET_REGISTRY._locked = False
         # lock registry to make sure assets aren't added after startup that would be missed by
         # extract_frontend_assets
         for prop_handler in self.REACT_PROP_HANDLERS:


### PR DESCRIPTION
Handle error with FrontendAssetRegistry that could occur in test cases when @modify_settings is used