### PR TITLE
Camel case prop keys only

### DIFF
--- a/.changeset/witty-dancers-collect.md
+++ b/.changeset/witty-dancers-collect.md
@@ -1,0 +1,5 @@
+---
+"alliance-platform-frontend": patch
+---
+
+`{% component %}` tag will now only convert prop names from `this_case` to `thisCase`. Previously this was converting nested dicts as well - so things like `{ MY_CONSTANT: 5}` became `{ MYCONSTANT: 5}`.

--- a/packages/ap-frontend/alliance_platform/frontend/templatetags/react.py
+++ b/packages/ap-frontend/alliance_platform/frontend/templatetags/react.py
@@ -158,7 +158,7 @@ class ComponentProps(SSRSerializable):
 
     def _serialize_prop(self, value: PropType, ssr_context: SSRSerializerContext):
         if isinstance(value, dict):
-            return {underscore_to_camel(k): self._serialize_prop(v, ssr_context) for k, v in value.items()}
+            return {k: self._serialize_prop(v, ssr_context) for k, v in value.items()}
         if isinstance(value, (list, tuple)):
             return [self._serialize_prop(v, ssr_context) for v in value]
         if isinstance(value, ComponentProp):
@@ -534,7 +534,7 @@ class ComponentSourceCodeGenerator:
 
     def _codegen_prop(self, value: PropType):
         if isinstance(value, dict):
-            return {underscore_to_camel(k): self._codegen_prop(v) for k, v in value.items()}
+            return {k: self._codegen_prop(v) for k, v in value.items()}
         if isinstance(value, (list, tuple)):
             return [self._codegen_prop(v) for v in value]
         if isinstance(value, CodeGeneratorNode):
@@ -559,7 +559,7 @@ class ComponentSourceCodeGenerator:
         flexible here as anything can technically be passed to `createElement`.
         """
         try:
-            return StringLiteral(key.lower()) if "-" in key else Identifier(underscore_to_camel(key))
+            return StringLiteral(key.lower()) if "-" in key else Identifier(key)
         except InvalidIdentifier:
             return StringLiteral(key)
 
@@ -930,7 +930,9 @@ class ComponentNode(template.Node, BundlerAsset):
                 props.update(extra_props)
         if self.html_attribute_template_nodes:
             props.update(self.html_attribute_template_nodes.resolve(context))
-        return ComponentProps({key: self.resolve_prop(value, context) for key, value in props.items()})
+        return ComponentProps(
+            {underscore_to_camel(key): self.resolve_prop(value, context) for key, value in props.items()}
+        )
 
     def _queue_css(self):
         css_items = self.bundler.get_embed_items(self.get_paths_for_bundling(), "text/css")

--- a/packages/ap-frontend/docs/templatetags.rst
+++ b/packages/ap-frontend/docs/templatetags.rst
@@ -380,7 +380,10 @@ for documentation about adding your own complex props.
 Components are rendered using the ``renderComponent`` function in :data:`~alliance_platform.frontend.settings.AlliancePlatformFrontendSettingsType.REACT_RENDER_COMPONENT_FILE`. This can be modified as needed,
 for example if a new provider is required.
 
-.. note:: All props passed through are converted to camel case automatically (i.e. ``my_prop`` will become ``myProp``)
+.. note::
+
+    All props passed through are converted to camel case automatically (i.e. ``my_prop`` will become ``myProp``). This
+    transformation only applies to the prop name itself, any objects passed will not be recursively converted.
 
 Server Side Rendering (SSR)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/packages/ap-frontend/tests/test_bundler_templatetags.py
+++ b/packages/ap-frontend/tests/test_bundler_templatetags.py
@@ -1048,3 +1048,17 @@ class TestComponentTemplateTagOutput(SimpleTestCase):
                 {% component "div" %}<input "=5 id="test">{% endcomponent %}""",
                 """<div><input id="test" /></div>""",
             )
+
+    def test_camel_case_top_level_only(self):
+        self.assertComponentEqual(
+            """
+            {% component "MyComponent" camel_case=5 %}{% endcomponent %}""",
+            """<MyComponent camelCase={5} />""",
+        )
+
+        self.assertComponentEqual(
+            """
+            {% component "MyComponent" camel_case=obj %}{% endcomponent %}""",
+            """<MyComponent camelCase={{CAMEL_KEY: { NESTED_CAMEL_KEY: "value"}}} />""",
+            obj={"CAMEL_KEY": {"NESTED_CAMEL_KEY": "value"}},
+        )


### PR DESCRIPTION
Don't recursively convert dict keys to camel case, it should only apply to the top level. This avoids things like converting `{ MY_CONSTANT: 5 }` into `{ MYCONSTANT: 5 }`.