### PR TITLE
Escape code generated within <script> tags

### DIFF
--- a/.changeset/pretty-dryers-glow.md
+++ b/.changeset/pretty-dryers-glow.md
@@ -1,0 +1,5 @@
+---
+"alliance-platform-codegen": patch
+---
+
+Add `RawNode` to codegen to support outputing code directly

--- a/.changeset/young-planes-move.md
+++ b/.changeset/young-planes-move.md
@@ -1,0 +1,6 @@
+---
+"alliance-platform-frontend": patch
+"alliance-platform-codegen": patch
+---
+
+Fix code generated for embedding with <script> tags to properly escape code and avoid XSS vulnerabilities. This affected the `{% component %}` tag.

--- a/packages/ap-codegen/alliance_platform/codegen/printer.py
+++ b/packages/ap-codegen/alliance_platform/codegen/printer.py
@@ -432,7 +432,9 @@ class TypescriptPrinter:
             return f"// {lines}"
 
         if isinstance(node, MultiLineComment):
-            return f"/* {node.comment_text} */"
+            # Handle */ in comments that would close the comment early
+            text = node.comment_text.replace("*/", "*\\/")
+            return f"/* {text} */"
 
         if isinstance(node, NullKeyword):
             return "null"

--- a/packages/ap-codegen/alliance_platform/codegen/printer.py
+++ b/packages/ap-codegen/alliance_platform/codegen/printer.py
@@ -40,6 +40,7 @@ from .typescript import ObjectLiteralExpression
 from .typescript import ObjectProperty
 from .typescript import Parameter
 from .typescript import PropertyAccessExpression
+from .typescript import RawNode
 from .typescript import ReturnStatement
 from .typescript import SingleLineComment
 from .typescript import SpreadAssignment
@@ -194,6 +195,8 @@ class TypescriptPrinter:
     @print_comments
     def print(self, node: NodeLike) -> str:  # noqa: T202
         """Recursively print the code for the specified ``node``"""
+        if isinstance(node, RawNode):
+            return node.code
         if isinstance(node, JsxText) or isinstance(node, StringLiteral) and self.is_within_jsx():
             if self.jsx_transform:
                 return self._format_literal(node.value)

--- a/packages/ap-codegen/alliance_platform/codegen/printer.py
+++ b/packages/ap-codegen/alliance_platform/codegen/printer.py
@@ -416,7 +416,13 @@ class TypescriptPrinter:
                 if not isinstance(child, Node):
                     child = convert_to_node(child)
                 if isinstance(child, StringLiteral):
-                    pieces.append(child.value)
+                    escaped_string = child.value.translate(
+                        (ESCAPE_TARGET_FILE if self.codegen_target == "file" else ESCAPE_TARGET_HTML)
+                        | {
+                            ord("`"): "\\`",
+                        }
+                    )
+                    pieces.append(escaped_string)
                 else:
                     pieces.append(f"${{{self.print(child)}}}")
             return f"`{''.join(pieces)}`"

--- a/packages/ap-codegen/alliance_platform/codegen/typescript.py
+++ b/packages/ap-codegen/alliance_platform/codegen/typescript.py
@@ -643,6 +643,21 @@ class JsxElement(Node):
     children: list[Union[JsxText, JsxExpression, "JsxElement"]]
 
 
+@dataclass
+class RawNode(Node):
+    """A raw node that will be output as is
+
+    This is useful if you have some code you want to manually craft as a string rather than building
+    up from nodes.
+
+    .. warning::
+
+        Be careful using this with any user input, as no escaping will be done.
+    """
+
+    code: str
+
+
 def construct_object_property_key(
     value: AcceptedPropertyKeyType,
 ) -> Identifier | NumericLiteral | StringLiteral:

--- a/packages/ap-codegen/tests/test_printer.py
+++ b/packages/ap-codegen/tests/test_printer.py
@@ -342,7 +342,7 @@ class TypescriptPrinterTestCase(SimpleTestCase):
                     [StringLiteral("Hello my name is "), Identifier("name"), ". What's yours?"]
                 )
             ),
-            "`Hello my name is ${name}. What's yours?`",
+            "`Hello my name is ${name}. What\\'s yours?`",
         )
 
     def test_new_expression(self):

--- a/packages/ap-codegen/tests/test_printer.py
+++ b/packages/ap-codegen/tests/test_printer.py
@@ -665,6 +665,11 @@ class TypescriptPrinterTestCase(SimpleTestCase):
             p.print(TemplateExpression(["See `ref` ", Identifier("name")])), "`See \\`ref\\` ${name}`"
         )
 
+    def test_multiline_comment_escape(self):
+        p = TypescriptPrinter()
+        self.assertEqual(p.print(MultiLineComment("Multiline comment")), "/* Multiline comment */")
+        self.assertEqual(p.print(MultiLineComment("Multiline comment */")), "/* Multiline comment *\/ */")
+
 
 fixtures_dir = settings.BASE_DIR / "alliance_platform_frontend/bundler/tests/fixtures"
 

--- a/packages/ap-codegen/tests/test_printer.py
+++ b/packages/ap-codegen/tests/test_printer.py
@@ -431,7 +431,7 @@ class TypescriptPrinterTestCase(SimpleTestCase):
         ]
         for jsx_transform, expected in tests:
             with self.subTest(jsx_transform=jsx_transform):
-                p = TypescriptPrinter(jsx_transform=jsx_transform)
+                p = TypescriptPrinter(jsx_transform=jsx_transform, codegen_target="file")
                 self.assertEqual(
                     p.print(
                         JsxElement(
@@ -624,6 +624,32 @@ class TypescriptPrinterTestCase(SimpleTestCase):
                     }
                 """
             ).strip(),
+        )
+
+    def test_escape_strings(self):
+        script_tag = "</script><script>alert('xss');</script>"
+        script_tag_encoded = "\\u003C/script\\u003E\\u003Cscript\\u003Ealert(\\'xss\\');\\u003C/script\\u003E"
+        node = JsxElement(
+            Identifier("Wrapper"),
+            [
+                JsxAttribute(
+                    StringLiteral("src"),
+                    StringLiteral(
+                        script_tag,
+                    ),
+                )
+            ],
+            [],
+        )
+        p = TypescriptPrinter()
+        self.assertEqual(
+            p.print(node),
+            'React.createElement(Wrapper, {"src": "%s"})' % script_tag_encoded,
+        )
+        p = TypescriptPrinter()
+        self.assertEqual(
+            p.print(node),
+            'React.createElement(Wrapper, {"src": "%s"})' % script_tag_encoded,
         )
 
 

--- a/packages/ap-codegen/tests/test_printer.py
+++ b/packages/ap-codegen/tests/test_printer.py
@@ -27,6 +27,7 @@ from alliance_platform.codegen.typescript import ObjectLiteralExpression
 from alliance_platform.codegen.typescript import ObjectProperty
 from alliance_platform.codegen.typescript import Parameter
 from alliance_platform.codegen.typescript import PropertyAccessExpression
+from alliance_platform.codegen.typescript import RawNode
 from alliance_platform.codegen.typescript import ReturnStatement
 from alliance_platform.codegen.typescript import SingleLineComment
 from alliance_platform.codegen.typescript import SpreadAssignment
@@ -599,6 +600,31 @@ class TypescriptPrinterTestCase(SimpleTestCase):
                     ),
                     expected,
                 )
+
+    def test_raw_node(self):
+        p = TypescriptPrinter()
+        self.assertEqual(
+            textwrap.dedent(
+                p.print(
+                    FunctionDeclaration(
+                        Identifier("renderButton"),
+                        [Parameter(Identifier("name"))],
+                        [
+                            RawNode('function myTest(test = "initial") { return test; }'),
+                            ReturnStatement(RawNode("myTest(name)")),
+                        ],
+                    )
+                )
+            ),
+            textwrap.dedent(
+                """
+                    function renderButton(name) {
+                      function myTest(test = "initial") { return test; };
+                    return myTest(name);
+                    }
+                """
+            ).strip(),
+        )
 
 
 fixtures_dir = settings.BASE_DIR / "alliance_platform_frontend/bundler/tests/fixtures"

--- a/packages/ap-codegen/tests/test_printer.py
+++ b/packages/ap-codegen/tests/test_printer.py
@@ -646,10 +646,23 @@ class TypescriptPrinterTestCase(SimpleTestCase):
             p.print(node),
             'React.createElement(Wrapper, {"src": "%s"})' % script_tag_encoded,
         )
-        p = TypescriptPrinter()
+        p = TypescriptPrinter(codegen_target="file")
         self.assertEqual(
             p.print(node),
-            'React.createElement(Wrapper, {"src": "%s"})' % script_tag_encoded,
+            'React.createElement(Wrapper, {"src": "</script><script>alert(\\\'xss\\\');</script>"})',
+        )
+
+    def test_template_string_escape(self):
+        script_tag = "</script><script>alert('xss');</script>"
+        script_tag_encoded = "\\u003C/script\\u003E\\u003Cscript\\u003Ealert(\\'xss\\');\\u003C/script\\u003E"
+        p = TypescriptPrinter()
+        self.assertEqual(
+            p.print(TemplateExpression([StringLiteral(script_tag), Identifier("name")])),
+            "`%s${name}`" % script_tag_encoded,
+        )
+
+        self.assertEqual(
+            p.print(TemplateExpression(["See `ref` ", Identifier("name")])), "`See \\`ref\\` ${name}`"
         )
 
 

--- a/packages/ap-frontend/alliance_platform/frontend/templatetags/react.py
+++ b/packages/ap-frontend/alliance_platform/frontend/templatetags/react.py
@@ -21,6 +21,7 @@ from alliance_platform.codegen.typescript import JsxElement
 from alliance_platform.codegen.typescript import MultiLineComment
 from alliance_platform.codegen.typescript import Node as TypescriptNode
 from alliance_platform.codegen.typescript import PropertyAccessExpression
+from alliance_platform.codegen.typescript import RawNode
 from alliance_platform.codegen.typescript import ReturnStatement
 from alliance_platform.codegen.typescript import StringLiteral
 from alliance_platform.codegen.typescript import UnconvertibleValueException
@@ -665,7 +666,7 @@ class ComponentSourceCodeGenerator:
                             Identifier("document"),
                             Identifier("querySelector"),
                         ),
-                        [f"[data-djid='{container_id}']"],
+                        [RawNode(f"\"[data-djid='{container_id}']\"")],
                     ),
                     jsx_element,
                     container_id,


### PR DESCRIPTION
Code generated was vulnerable to XSS due to missing escaping, these changes mitigate that


Don't merge yet - I'll review again myself tomorrow and test further against a project that's using the tag pretty extensively first before releasing, but so far everything I've tested against has been fine.