### PR TITLE
fix: handle components as props correctly

### DIFF
--- a/.changeset/pink-turtles-repair.md
+++ b/.changeset/pink-turtles-repair.md
@@ -1,0 +1,5 @@
+---
+"alliance-platform-frontend": patch
+---
+
+Fix `{% component %}` handling of HTML help_text. Previously, a component coming through in help_text from `{% form_input %}` would be outputted as its escaped embed code rather than rendering it.

--- a/packages/ap-frontend/alliance_platform/frontend/templatetags/react.py
+++ b/packages/ap-frontend/alliance_platform/frontend/templatetags/react.py
@@ -861,6 +861,9 @@ class ComponentNode(template.Node, BundlerAsset):
         to convert values to the new type.
         """
 
+        # Always handle this first, as ``ComponentNode`` is also a ``Node`` but shouldn't be rendered directly here
+        if isinstance(value, ComponentNode):
+            return NestedComponentProp(value, self, context)
         # In the case of raw HTML that is transformed with the ``convert_html_string`` function we need to handle
         # the case of a template node being used as a prop, e.g. ``<a href="{% url 'some-url' %}">``.
         if isinstance(value, Node):
@@ -913,9 +916,6 @@ class ComponentNode(template.Node, BundlerAsset):
         if isinstance(value, FilterExpression):
             value = value.resolve(context)
             return self.resolve_prop(value, context)
-        # Always handle this first as many things rely on NestedComponentProp being here
-        if isinstance(value, ComponentNode):
-            return NestedComponentProp(value, self, context)
         return resolve_prop(value, self, context)
 
     def resolve_props(self, context: Context) -> ComponentProps:


### PR DESCRIPTION
Fix `{% component %}` handling of HTML help_text. Previously, a component coming through in help_text from `{% form_input %}` would be outputted as its escaped embed code rather than rendering it.