### PR TITLE
fix: prop handlers handle microsecond conversion

### DIFF
--- a/.changeset/empty-doors-complain.md
+++ b/.changeset/empty-doors-complain.md
@@ -1,0 +1,5 @@
+---
+"alliance-platform-frontend": patch
+---
+
+Fix prop handlers for `Time`, `CalendarDateTime` and `ZonedDateTime` to convert microseconds to milliseconds. Javascript doesn't support microseconds, so convert to milliseconds.

--- a/packages/ap-frontend/alliance_platform/frontend/prop_handlers.py
+++ b/packages/ap-frontend/alliance_platform/frontend/prop_handlers.py
@@ -92,6 +92,14 @@ class ComponentProp(SSRCustomFormatSerializable, CodeGeneratorNode):
         return []
 
 
+def convert_microseconds(value: int) -> int:
+    """Convert microseconds to milliseconds
+
+    Javascript doesn't support microseconds, only milliseconds.
+    """
+    return int(value / 1000)
+
+
 class DateProp(ComponentProp):
     """Convert a python date or datetime to a js Date"""
 
@@ -138,7 +146,7 @@ class DateTimeProp(ComponentProp):
             self.value.hour,
             self.value.minute,
             self.value.second,
-            self.value.microsecond,
+            convert_microseconds(self.value.microsecond),
         ]
 
     def get_tag(self):
@@ -187,7 +195,7 @@ class ZonedDateTimeProp(ComponentProp):
             self.value.hour,
             self.value.minute,
             self.value.second,
-            self.value.microsecond,
+            convert_microseconds(self.value.microsecond),
         ]
 
     def get_tag(self):
@@ -222,7 +230,12 @@ class TimeProp(ComponentProp):
     def __init__(self, value, *args, **kwargs):
         super().__init__(value, *args, **kwargs)
         self.value = value
-        self.js_args = [self.value.hour, self.value.minute, self.value.second, self.value.microsecond]
+        self.js_args = [
+            self.value.hour,
+            self.value.minute,
+            self.value.second,
+            convert_microseconds(self.value.microsecond),
+        ]
 
     def get_tag(self):
         return "Time"

--- a/packages/ap-frontend/tests/test_bundler_templatetags.py
+++ b/packages/ap-frontend/tests/test_bundler_templatetags.py
@@ -748,21 +748,21 @@ class TestComponentTemplateTagCodeGen(SimpleTestCase):
                 self.assertSerializedPropsEqual(
                     "{% load react %}" "{% component 'DateTimePicker' datetime=datetime %}{% endcomponent %}",
                     {
-                        "datetime": datetime.datetime(2022, 12, 1, 12, 10, 10, 0),
+                        "datetime": datetime.datetime(2022, 12, 1, 12, 10, 10, 213000),
                     },
-                    {"datetime": ["@@CUSTOM", "DateTime", [2022, 12, 1, 12, 10, 10, 0]]},
+                    {"datetime": ["@@CUSTOM", "DateTime", [2022, 12, 1, 12, 10, 10, 213]]},
                 )
 
                 self.assertSerializedPropsEqual(
                     "{% load react %}" "{% component 'DateTimePicker' datetime=datetime %}{% endcomponent %}",
                     {
-                        "datetime": make_aware(datetime.datetime(2022, 12, 1, 12, 10, 10, 0)),
+                        "datetime": make_aware(datetime.datetime(2022, 12, 1, 12, 10, 10, 50000)),
                     },
                     {
                         "datetime": [
                             "@@CUSTOM",
                             "ZonedDateTime",
-                            [2022, 12, 1, "Australia/Melbourne", 39600000, 12, 10, 10, 0],
+                            [2022, 12, 1, "Australia/Melbourne", 39600000, 12, 10, 10, 50],
                         ]
                     },
                 )
@@ -775,7 +775,7 @@ class TestComponentTemplateTagCodeGen(SimpleTestCase):
                 self.assertSerializedPropsEqual(
                     "{% load react %}" "{% component 'Time' time=time %}{% endcomponent %}",
                     {
-                        "time": datetime.time(12, 30, 15, 5),
+                        "time": datetime.time(12, 30, 15, 5000),
                     },
                     {
                         "time": [


### PR DESCRIPTION
Fix prop handlers for `Time`, `CalendarDateTime` and `ZonedDateTime` to convert microseconds to milliseconds. Javascript doesn't support microseconds, so convert to milliseconds