### PR TITLE
feature: add templatetag and filter for generating and passing querydicts to urls

### DIFF
--- a/.changeset/four-elephants-breathe.md
+++ b/.changeset/four-elephants-breathe.md
@@ -2,4 +2,4 @@
 "alliance-platform-ui": patch
 ---
 
-Add query_dict templatetag and with_params filter
+Add [create_dict](https://alliance-platform.readthedocs.io/projects/ui/latest/templatetags.html#create-dict) templatetag and [with_params](https://alliance-platform.readthedocs.io/projects/ui/latest/templatetags.html#with-params) filter

--- a/.changeset/four-elephants-breathe.md
+++ b/.changeset/four-elephants-breathe.md
@@ -1,0 +1,5 @@
+---
+"alliance-platform-ui": patch
+---
+
+Add query_dict templatetag and with_params filter

--- a/packages/ap-ui/docs/templatetags.rst
+++ b/packages/ap-ui/docs/templatetags.rst
@@ -449,11 +449,18 @@ this for the props to be passed through:
 
         {% form_input field non_standard_widget=True %}
 
-``query_params``
+.. templatetag:: create_dict
+
+``create_dict``
 ----------------
 
-Add a dictionary to the template context with keys set by arbitrary keyword arguments, to pass to the ``with_params`` filter. See :tfilter:`with_params`
-for usage example.
+Add a dictionary to the template context with keys set by arbitrary keyword arguments. Can be used to generate URL kwargs or
+query parameters to :tfilter:`url_with_perm` or :tfilter:`url`.
+
+.. code-block:: html+django
+
+    {% create_dict kwarg=2 id=record.pk as my_kwargs %}
+    {% Button href="my_url"|url_with_perm|with_kwargs:my_kwargs %}
 
 Filters
 -------
@@ -477,21 +484,32 @@ Usage:
 
 The above example will resolve the URL "my_url_name" with the argument ``2``.
 
-If you need multiple arguments you can use the ``with_arg`` filter:
+If you need multiple arguments you can use the :tfilter:`with_arg` filter:
 
 .. code-block:: html+django
 
     {% component "a" href="my_url_name"|url_with_perm:2|with_arg:"another arg" %}Link{% endcomponent %}
 
-To pass kwargs you can use the ``with_kwargs`` filter:
+To pass kwargs you can use the :tfilter:`with_kwargs` filter:
 
 .. code-block:: html+django
 
     {% component "a" href="my_url_name"|url_with_perm|with_kwargs:my_kwargs %}Link{% endcomponent %}
 
-Note that as there's no way to define a dictionary in the standard Django template language, you'll need to
-pass it in context.
+To pass query parameters you can use the :tfilter:`with_params` filter:
 
+.. code-block:: html+django
+
+    {% component "a" href="my_url_name"|url_with_perm|with_params:my_params %}Link{% endcomponent %}
+
+For both kwargs and params, you can either pass a dictionary through context, or generate one in the template
+using the :ttag:`create_dict` templatetag:
+
+.. code-block:: html+django
+
+    {% create_dict param=1 as my_query %}
+    {% create_dict kwarg=2 id=record.pk as my_kwargs %}
+    {% Button href="my_url"|url_with_perm|with_query:my_query|with_kwargs:my_kwargs %}
 
 To do object level permission checks use the ``with_perm_obj`` filter to pass through the object:
 
@@ -552,9 +570,12 @@ Add kwargs to a :tfilter:`url_with_perm` or :tfilter:`url` filter.
 
 Add query params to a :tfilter:`url_with_perm` or :tfilter:`url` filter.
 
+Accepts a dictionary, ``QueryDict``, or a string (which will be parsed as a ``QueryDict``). A dictionary can be generated in the template
+with the :ttag:`create_dict` templatetag, or passed directly to context in the corresponding view.
+
 .. code-block:: html+django
 
-    {% query_params x=1 id=record.pk as my_query %}
+    {% create_dict x=1 id=record.pk as my_query %}
     {% Button href="my_url"|url_with_perm|with_query:my_query %}
 
 .. templatefilter:: with_perm_object

--- a/packages/ap-ui/docs/templatetags.rst
+++ b/packages/ap-ui/docs/templatetags.rst
@@ -449,6 +449,12 @@ this for the props to be passed through:
 
         {% form_input field non_standard_widget=True %}
 
+``query_params``
+----------------
+
+Add a dictionary to the template context with keys set by arbitrary keyword arguments, to pass to the ``with_params`` filter. See :tfilter:`with_params`
+for usage example.
+
 Filters
 -------
 
@@ -538,6 +544,18 @@ Add kwargs to a :tfilter:`url_with_perm` or :tfilter:`url` filter.
 .. code-block:: html+django
 
     {% component "a" href="my_url_name"|url_with_perm|with_kwargs:my_kwargs %}Link{% endcomponent %}
+
+.. templatefilter:: with_params
+
+``with_params``
+--------------------
+
+Add query params to a :tfilter:`url_with_perm` or :tfilter:`url` filter.
+
+.. code-block:: html+django
+
+    {% query_params x=1 id=record.pk as my_query %}
+    {% Button href="my_url"|url_with_perm|with_query:my_query %}
 
 .. templatefilter:: with_perm_object
 

--- a/packages/ap-ui/tests/test_alliance_ui_templatetags.py
+++ b/packages/ap-ui/tests/test_alliance_ui_templatetags.py
@@ -196,17 +196,33 @@ class UrlFilterPermTemplateTagsTestCase(TestCase):
                 """
             {% load react %}
             {% load alliance_platform.ui %}
-            {% query_params strparam="test" user_id=user.pk as my_params %}
-            {% component "a" href=perm|url_with_perm:user.pk|with_params:my_params|with_perm_obj:user %}{% endcomponent %}
+            {% query_params templateparam="test" user_id=user.pk as my_params %}
+            {% component "a" href=perm|url_with_perm:user.pk|with_params:context_params|with_params:str_params|with_params:my_params|with_perm_obj:user %}{% endcomponent %}
             """
             )
 
-            params_dict = {"strparam": "test", "user_id": user1.pk}
+            context_params_dict = {"contextparam": "test"}
+            context_params_str = "&stringparam=test"
+            template_params_dict = {"templateparam": "test", "user_id": user1.pk}
+
+            params_dict = {
+                **context_params_dict,
+                "stringparam": "test",
+                **template_params_dict,
+            }
 
             request = HttpRequest()
             request.user = user2
             request.session = SessionBase()
-            context = Context({"request": request, "user": user1, "perm": self.OBJECT_PERM_URL})
+            context = Context(
+                {
+                    "request": request,
+                    "user": user1,
+                    "perm": self.OBJECT_PERM_URL,
+                    "context_params": context_params_dict,
+                    "str_params": context_params_str,
+                }
+            )
             output = tpl.render(context)
             self.assertEqual(output.strip(), "")
             request.user = user1

--- a/packages/ap-ui/tests/test_alliance_ui_templatetags.py
+++ b/packages/ap-ui/tests/test_alliance_ui_templatetags.py
@@ -6,7 +6,9 @@ from alliance_platform.frontend.bundler.context import BundlerAssetContext
 from allianceutils.auth.permission import AmbiguousGlobalPermissionWarning
 from allianceutils.tests.util import warning_filter
 from django.contrib.sessions.backends.base import SessionBase
+from django.core.exceptions import TooManyFieldsSent
 from django.http import HttpRequest
+from django.http import QueryDict
 from django.template import Context
 from django.template import Template
 from django.test import TestCase
@@ -32,7 +34,7 @@ from .test_utils.bundler import bypass_frontend_asset_registry
         "rules.permissions.ObjectPermissionBackend",
     ),
 )
-@override_settings(ROOT_URLCONF="test_alliance_platform_ui.urls")
+@override_settings(ROOT_URLCONF="test_alliance_platform_ui.urls", DATA_UPLOAD_MAX_NUMBER_FIELDS=10)
 @warning_filter("ignore", category=AmbiguousGlobalPermissionWarning)
 class UrlFilterPermTemplateTagsTestCase(TestCase):
     PERM = "test_utils.link_is_allowed"
@@ -196,19 +198,19 @@ class UrlFilterPermTemplateTagsTestCase(TestCase):
                 """
             {% load react %}
             {% load alliance_platform.ui %}
-            {% query_params templateparam="test" user_id=user.pk as my_params %}
+            {% create_dict templateparam="test" user_id=user.pk as my_params %}
             {% component "a" href=perm|url_with_perm:user.pk|with_params:context_params|with_params:str_params|with_params:my_params|with_perm_obj:user %}{% endcomponent %}
             """
             )
 
             context_params_dict = {"contextparam": "test"}
             context_params_str = "&stringparam=test"
-            template_params_dict = {"templateparam": "test", "user_id": user1.pk}
+            template_params_querydict = QueryDict(f"templateparam=test&user_id={user1.pk}")
 
             params_dict = {
                 **context_params_dict,
                 "stringparam": "test",
-                **template_params_dict,
+                **template_params_querydict.dict(),
             }
 
             request = HttpRequest()
@@ -233,6 +235,36 @@ class UrlFilterPermTemplateTagsTestCase(TestCase):
             ).replace("&", r"\u0026")
 
             self.assertTrue(f'href: "{url}"' in output)
+
+    def test_reject_incorrect_params(self):
+        user1 = self.get_privileged_user()
+        user2 = self.get_unprivileged_user()
+
+        with self.setup_overrides():
+            tpl = Template(
+                """
+            {% load react %}
+            {% load alliance_platform.ui %}
+            {% create_dict templateparam="test" user_id=user.pk as my_params %}
+            {% component "a" href=perm|url_with_perm:user.pk|with_params:context_params_str|with_perm_obj:user %}{% endcomponent %}
+            """
+            )
+
+            context_params_str = "&".join([f"param{n}=test" for n in range(11)])
+
+            request = HttpRequest()
+            request.user = user2
+            request.session = SessionBase()
+            context = Context(
+                {
+                    "request": request,
+                    "user": user1,
+                    "perm": self.OBJECT_PERM_URL,
+                    "context_params_str": context_params_str,
+                }
+            )
+            with self.assertRaises(TooManyFieldsSent):
+                tpl.render(context)
 
     def test_url_no_perm_check(self):
         user1 = self.get_privileged_user()


### PR DESCRIPTION
## [AP159: Allow passing query params to url templatetags](https://kanban.alliancesoftware.com.au/board/75/card/141787/summary/)
