### PR TITLE
fix: specify path_base when writing source

### DIFF
--- a/.changeset/popular-carrots-buy.md
+++ b/.changeset/popular-carrots-buy.md
@@ -1,0 +1,5 @@
+---
+"alliance-platform-frontend": patch
+---
+
+Fix usages where bundler root directory does not match the default project dir (e.g. in a mono-repo)

--- a/packages/ap-codegen/alliance_platform/codegen/registry.py
+++ b/packages/ap-codegen/alliance_platform/codegen/registry.py
@@ -198,7 +198,7 @@ class CodegenRegistry:
         if not cache_key:
             raise ValueError("Registration has no cache key")
         class_id = f"{registration.__class__.__module__}.{registration.__class__.__qualname__}"
-        return f'{class_id}.{cache_key["registration_id"]}'
+        return f"{class_id}.{cache_key['registration_id']}"
 
     def has_dependencies_changed(self, registration: CodegenRegistration, stats: CodegenStats) -> bool:
         cache_key = registration.get_cache_key()

--- a/packages/ap-codegen/tests/test_printer.py
+++ b/packages/ap-codegen/tests/test_printer.py
@@ -570,9 +570,7 @@ class TypescriptPrinterTestCase(SimpleTestCase):
             (None, "<Wrapper element={\n/* Leading comment */\n<Inner />} />"),
             (
                 Identifier("createElement"),
-                'createElement(Wrapper, {"element": createElement(\n'
-                "/* Leading comment */\n"
-                "Inner, {})})",
+                'createElement(Wrapper, {"element": createElement(\n/* Leading comment */\nInner, {})})',
             ),
         ]
         for jsx_transform, expected in tests:

--- a/packages/ap-frontend/alliance_platform/frontend/templatetags/react.py
+++ b/packages/ap-frontend/alliance_platform/frontend/templatetags/react.py
@@ -487,6 +487,7 @@ class ComponentSourceCodeGenerator:
         self.bundler = node.bundler
         self._writer = TypescriptSourceFileWriter(
             resolve_import_url=self._resolve_import_url,
+            path_base=self.bundler.root_dir,
         )
         self._requires_wrapper_component = False
         self._used_identifiers = []

--- a/packages/ap-frontend/alliance_platform/frontend/templatetags/react.py
+++ b/packages/ap-frontend/alliance_platform/frontend/templatetags/react.py
@@ -1060,7 +1060,7 @@ def react_refresh_preamble():
         # Indentation level here chose to generate prettier HTML source ;)
         f"""
     <script type="module">
-      import RefreshRuntime from '{bundler.get_url('@react-refresh')}';
+      import RefreshRuntime from '{bundler.get_url("@react-refresh")}';
 
       RefreshRuntime.injectIntoGlobalHook(window)
       window.$RefreshReg$ = () => {{}}

--- a/packages/ap-frontend/tests/test_bundler_templatetags.py
+++ b/packages/ap-frontend/tests/test_bundler_templatetags.py
@@ -260,7 +260,7 @@ class TestBundlerTemplateTags(SimpleTestCase):
             (
                 "test_production_bundler",
                 '<script src="/static/assets/Button-def456.js" type="module"></script>\n'
-                f'<style>{inline_css_prod[fixtures_dir / "build_test/assets/Button-abc123.css"]}</style>',
+                f"<style>{inline_css_prod[fixtures_dir / 'build_test/assets/Button-abc123.css']}</style>",
             ),
         ]:
             with self.subTest(bundler_name=bundler_name):
@@ -573,8 +573,7 @@ class TestComponentTemplateTagCodeGen(SimpleTestCase):
             mock_method.return_value = container_id
             for context_vars, expected_output in test_strings:
                 tpl = Template(
-                    "{% load react %}"
-                    "{% component 'Component' props=props %}{{ children }}{% endcomponent %}"
+                    "{% load react %}{% component 'Component' props=props %}{{ children }}{% endcomponent %}"
                 )
                 context = Context(context_vars)
                 contents = tpl.render(context)
@@ -598,7 +597,7 @@ class TestComponentTemplateTagCodeGen(SimpleTestCase):
             container_id = "C1"
             mock_method.return_value = container_id
             tpl = Template(
-                "{% load react %}" "{% component 'Component' description=help_text %}{% endcomponent %}"
+                "{% load react %}{% component 'Component' description=help_text %}{% endcomponent %}"
             )
             context = Context(
                 {
@@ -738,7 +737,7 @@ class TestComponentTemplateTagCodeGen(SimpleTestCase):
         ):
             with BundlerAssetContext(frontend_asset_registry=bypass_frontend_asset_registry):
                 self.assertSerializedPropsEqual(
-                    "{% load react %}" "{% component 'DatePicker' date=date %}{% endcomponent %}",
+                    "{% load react %}{% component 'DatePicker' date=date %}{% endcomponent %}",
                     {
                         "date": datetime.date(2022, 12, 1),
                     },
@@ -746,7 +745,7 @@ class TestComponentTemplateTagCodeGen(SimpleTestCase):
                 )
 
                 self.assertSerializedPropsEqual(
-                    "{% load react %}" "{% component 'DateTimePicker' datetime=datetime %}{% endcomponent %}",
+                    "{% load react %}{% component 'DateTimePicker' datetime=datetime %}{% endcomponent %}",
                     {
                         "datetime": datetime.datetime(2022, 12, 1, 12, 10, 10, 213000),
                     },
@@ -754,7 +753,7 @@ class TestComponentTemplateTagCodeGen(SimpleTestCase):
                 )
 
                 self.assertSerializedPropsEqual(
-                    "{% load react %}" "{% component 'DateTimePicker' datetime=datetime %}{% endcomponent %}",
+                    "{% load react %}{% component 'DateTimePicker' datetime=datetime %}{% endcomponent %}",
                     {
                         "datetime": make_aware(datetime.datetime(2022, 12, 1, 12, 10, 10, 50000)),
                     },
@@ -773,7 +772,7 @@ class TestComponentTemplateTagCodeGen(SimpleTestCase):
         ):
             with BundlerAssetContext(frontend_asset_registry=bypass_frontend_asset_registry):
                 self.assertSerializedPropsEqual(
-                    "{% load react %}" "{% component 'Time' time=time %}{% endcomponent %}",
+                    "{% load react %}{% component 'Time' time=time %}{% endcomponent %}",
                     {
                         "time": datetime.time(12, 30, 15, 5000),
                     },


### PR DESCRIPTION
This helps in cases where the bundler `root_dir` has been changed and no longer matches the default PROJECT_DIR. For example, the project source may be in a sub directory within the repo, but the node_modules directory or other shared source may be at a level higher. `root_dir` has to encompass all source files and so must be set to the highest level.