### PR TITLE
fix: put render block back in bundler context for pdf generation

### DIFF
--- a/.changeset/wild-maps-laugh.md
+++ b/.changeset/wild-maps-laugh.md
@@ -1,0 +1,5 @@
+---
+"alliance-platform-pdf": patch
+---
+
+Fix PDF rendering with AP frontend by moving render block back into context

--- a/packages/ap-pdf/alliance_platform/pdf/decorators.py
+++ b/packages/ap-pdf/alliance_platform/pdf/decorators.py
@@ -99,14 +99,18 @@ def view_as_pdf(
                             headers[key] = val
                             request.META[key] = val
 
-            response = func(request, *args, **kwargs)
-            if hasattr(response, "render") and callable(response.render):
-                response = response.render()
-
             if AP_FRONTEND_INSTALLED:
                 with BundlerAssetContext(request=request) as asset_context:
+                    response = func(request, *args, **kwargs)
+                    if hasattr(response, "render") and callable(response.render):
+                        response = response.render()
+
                     if asset_context.requires_post_processing():
                         response.content = asset_context.post_process(response.content.decode()).encode()
+            else:
+                response = func(request, *args, **kwargs)
+                if hasattr(response, "render") and callable(response.render):
+                    response = response.render()
 
             if render_as_pdf:
                 url = request.build_absolute_uri(request.path if not url_path else url_path)


### PR DESCRIPTION
## [AP153: Migrate common_pdf](https://kanban.alliancesoftware.com.au/board/75/card/141330/summary/)
