### PR TITLE
fix: never exclude ap templates from being discovered

### DIFF
--- a/.changeset/young-shirts-move.md
+++ b/.changeset/young-shirts-move.md
@@ -1,0 +1,5 @@
+---
+"alliance-platform-frontend": patch
+---
+
+Don't allow alliance_platform package templates to be excluded from discovery with the `EXTRACT_ASSETS_EXCLUDE_DIRS` option.

--- a/packages/ap-frontend/alliance_platform/frontend/management/commands/extract_frontend_assets.py
+++ b/packages/ap-frontend/alliance_platform/frontend/management/commands/extract_frontend_assets.py
@@ -34,13 +34,16 @@ def get_all_templates_files() -> list[Path]:
     files: list[Path] = []
     for dir in dirs:
         should_exclude = False
-        for excl in ap_frontend_settings.EXTRACT_ASSETS_EXCLUDE_DIRS:
-            if isinstance(excl, re.Pattern):
-                if excl.match(str(dir)):
+        # Never exclude alliance platform templates - we need them included to handle
+        # usages of template tags
+        if "alliance_platform" not in str(dir):
+            for excl in ap_frontend_settings.EXTRACT_ASSETS_EXCLUDE_DIRS:
+                if isinstance(excl, re.Pattern):
+                    if excl.match(str(dir)):
+                        should_exclude = True
+                        break
+                elif str(dir).startswith(str(excl)):
                     should_exclude = True
-                    break
-            elif str(dir).startswith(str(excl)):
-                should_exclude = True
 
         # always include the frontend templates dir even if would otherwise
         # be excluded


### PR DESCRIPTION
Avoids confusing errors where you get UndiscoverableAssetError when using a template from alliance_platform when the EXTRACT_ASSETS_EXCLUDE_DIRS is set to something like site-packages/*