### PR TITLE
fix: support inline style tags

### DIFF
--- a/.changeset/seven-dryers-build.md
+++ b/.changeset/seven-dryers-build.md
@@ -1,0 +1,5 @@
+---
+"alliance-platform-frontend": patch
+---
+
+Support inline style props in component tags

--- a/packages/ap-frontend/alliance_platform/frontend/templatetags/react.py
+++ b/packages/ap-frontend/alliance_platform/frontend/templatetags/react.py
@@ -958,9 +958,14 @@ class ComponentNode(template.Node, BundlerAsset):
                 props.update(extra_props)
         if self.html_attribute_template_nodes:
             props.update(self.html_attribute_template_nodes.resolve(context))
-        return ComponentProps(
-            {underscore_to_camel(key): self.resolve_prop(value, context) for key, value in props.items()}
-        )
+        resolved_props = {}
+        for key, value in props.items():
+            resolved_key = underscore_to_camel(key)
+            resolved_value = self.resolve_prop(value, context)
+            if resolved_key == "style" and isinstance(resolved_value, str):
+                resolved_value = transform_attribute_names({"style": resolved_value})["style"]
+            resolved_props[resolved_key] = resolved_value
+        return ComponentProps(resolved_props)
 
     def _queue_css(self):
         css_items = self.bundler.get_embed_items(self.get_paths_for_bundling(), "text/css")

--- a/packages/ap-frontend/alliance_platform/frontend/util.py
+++ b/packages/ap-frontend/alliance_platform/frontend/util.py
@@ -183,7 +183,9 @@ def _split_css_property_and_value(declaration: str) -> tuple[str, str] | None:
         if char == "(":
             paren_depth += 1
             continue
-        if char == ")" and paren_depth > 0:
+        if char == ")":
+            if paren_depth == 0:
+                return None
             paren_depth -= 1
             continue
         if char == ":" and paren_depth == 0 and split_index is None:

--- a/packages/ap-frontend/docs/templatetags.rst
+++ b/packages/ap-frontend/docs/templatetags.rst
@@ -546,6 +546,9 @@ Convert html attributes to casing expected by JSX
 
 Calls :meth:`~alliance_platform.frontend.util.transform_attribute_names`
 
+If a ``style`` attribute is passed as a CSS string (e.g. ``"margin-right: 5px"``), it will be converted to
+the object form React expects (e.g. ``{"marginRight": "5px"}``).
+
 Usage:
 
 .. code-block:: html+django

--- a/packages/ap-frontend/tests/test_util.py
+++ b/packages/ap-frontend/tests/test_util.py
@@ -1,0 +1,95 @@
+from alliance_platform.frontend.bundler.context import BundlerAssetContext
+from alliance_platform.frontend.templatetags.react import CommonComponentSource
+from alliance_platform.frontend.templatetags.react import ComponentNode
+from alliance_platform.frontend.util import transform_attribute_names
+from django.template import Context
+from django.template import Origin
+from django.test import SimpleTestCase
+
+from tests.test_utils.bundler import bypass_frontend_asset_registry
+
+
+class TestTransformAttributeNames(SimpleTestCase):
+    def test_style_string_is_converted_to_style_object(self):
+        attrs = transform_attribute_names({"style": "margin-right: 5px; color: red;"})
+        self.assertEqual(
+            attrs,
+            {
+                "style": {
+                    "marginRight": "5px",
+                    "color": "red",
+                }
+            },
+        )
+
+    def test_style_parser_handles_semicolons_inside_values(self):
+        attrs = transform_attribute_names(
+            {"style": 'background-image: url("data:image/svg+xml;base64,abc;def"); margin-right: 5px'}
+        )
+        self.assertEqual(
+            attrs["style"],
+            {
+                "backgroundImage": 'url("data:image/svg+xml;base64,abc;def")',
+                "marginRight": "5px",
+            },
+        )
+
+    def test_style_parser_handles_custom_properties_and_vendor_prefixes(self):
+        attrs = transform_attribute_names(
+            {"style": "-webkit-line-clamp: 2; -ms-transition: all 1s; --custom-color: red;"}
+        )
+        self.assertEqual(
+            attrs["style"],
+            {
+                "WebkitLineClamp": "2",
+                "msTransition": "all 1s",
+                "--custom-color": "red",
+            },
+        )
+
+    def test_style_parser_preserves_values_as_plain_strings(self):
+        attrs = transform_attribute_names(
+            {"style": "background-image: url('</script><script>alert(1)</script>')"}
+        )
+        self.assertEqual(
+            attrs["style"],
+            {
+                "backgroundImage": "url('</script><script>alert(1)</script>')",
+            },
+        )
+
+    def test_style_parser_ignores_invalid_declarations(self):
+        attrs = transform_attribute_names({"style": "margin-right 5px; color: red; : bad; font-size: 12px"})
+        self.assertEqual(
+            attrs["style"],
+            {
+                "color": "red",
+                "fontSize": "12px",
+            },
+        )
+
+    def test_style_parser_returns_empty_for_garbage(self):
+        attrs = transform_attribute_names({"style": ";;;; not-a-declaration"})
+        self.assertEqual(attrs["style"], {})
+
+    def test_style_parser_ignores_unmatched_quotes(self):
+        attrs = transform_attribute_names({"style": "color: 'red; font-size: 12px"})
+        self.assertEqual(attrs["style"], {})
+
+    def test_style_parser_ignores_trailing_colon(self):
+        attrs = transform_attribute_names({"style": "color: red; width:"})
+        self.assertEqual(attrs["style"], {"color": "red", "width": ""})
+
+    def test_style_parser_handles_only_custom_properties(self):
+        attrs = transform_attribute_names({"style": "--primary-color: blue; --spacing: 4px;"})
+        self.assertEqual(attrs["style"], {"--primary-color": "blue", "--spacing": "4px"})
+
+    def test_component_node_converts_style_prop_string(self):
+        with BundlerAssetContext(frontend_asset_registry=bypass_frontend_asset_registry, skip_checks=True):
+            node = ComponentNode(
+                Origin("test"),
+                CommonComponentSource("div"),
+                {"style": "margin-right: 5px"},
+            )
+            props = node.resolve_props(Context())
+            self.assertEqual(props.props["style"], {"marginRight": "5px"})

--- a/packages/ap-frontend/tests/test_util.py
+++ b/packages/ap-frontend/tests/test_util.py
@@ -76,6 +76,20 @@ class TestTransformAttributeNames(SimpleTestCase):
         attrs = transform_attribute_names({"style": "color: 'red; font-size: 12px"})
         self.assertEqual(attrs["style"], {})
 
+    def test_style_parser_ignores_unmatched_open_parenthesis(self):
+        attrs = transform_attribute_names({"style": "color: red; transform: translate(10px"})
+        self.assertEqual(attrs["style"], {"color": "red"})
+
+    def test_style_parser_ignores_unmatched_close_parenthesis(self):
+        attrs = transform_attribute_names({"style": "color: red; transform: translateX(10px)); width: 5px"})
+        self.assertEqual(
+            attrs["style"],
+            {
+                "color": "red",
+                "width": "5px",
+            },
+        )
+
     def test_style_parser_ignores_trailing_colon(self):
         attrs = transform_attribute_names({"style": "color: red; width:"})
         self.assertEqual(attrs["style"], {"color": "red", "width": ""})


### PR DESCRIPTION
This supports both as a prop directly to {% component %}, and nested within on html tags

Resoles #98