### PR TITLE
feat(ap-storage): add async upload metadata and default async file widget template

### DIFF
--- a/.changeset/happy-gorillas-clap.md
+++ b/.changeset/happy-gorillas-clap.md
@@ -1,0 +1,5 @@
+---
+"alliance-platform-storage": patch
+---
+
+Add support for @alliancesoftware/ui/hook-form widget. This introduces some changes to the upload URL generation so widget can switch implementation based on backend requirements (e.g. POST vs PUT, form field requirements etc). These changes are additive to the API response so existing custom widgets should be compatible.

--- a/packages/ap-storage/alliance_platform/storage/async_uploads/storage/azure.py
+++ b/packages/ap-storage/alliance_platform/storage/async_uploads/storage/azure.py
@@ -75,7 +75,13 @@ class AzureAsyncUploadStorage(AzureStorage, AsyncUploadStorage):
             **generate_blob_kwargs,
         )
         container_blob_url = self.client.get_blob_client(name).url
-        return {"url": BlobClient.from_blob_url(container_blob_url, credential=credential).url, "fields": {}}
+        return {
+            "url": BlobClient.from_blob_url(container_blob_url, credential=credential).url,
+            "fields": {},
+            "method": "PUT",
+            "provider": "azure",
+            "headers": {"x-ms-blob-type": "BlockBlob"},
+        }
 
     def generate_download_url(
         self, key: str, field_id: str, expire=ap_storage_settings.DOWNLOAD_URL_EXPIRY, **kwargs

--- a/packages/ap-storage/alliance_platform/storage/async_uploads/storage/base.py
+++ b/packages/ap-storage/alliance_platform/storage/async_uploads/storage/base.py
@@ -1,6 +1,7 @@
 import datetime
 import os
 from typing import TYPE_CHECKING
+from typing import NotRequired
 from typing import TypedDict
 
 from django.core.exceptions import SuspiciousFileOperation
@@ -16,7 +17,15 @@ class GenerateUploadUrlResponse(TypedDict):
     #: The URL to post to
     url: str
     #: A dictionary of form field names and their values to be included when submitting
-    fields: dict
+    fields: dict[str, str]
+    #: Optional HTTP method the upload should use (for example POST or PUT).
+    method: NotRequired[str]
+    #: Optional provider identifier for frontend adapter selection (for example s3 or azure).
+    provider: NotRequired[str]
+    #: Optional HTTP headers required for upload.
+    headers: NotRequired[dict[str, str]]
+    #: Optional multipart field name for file POST uploads.
+    fileFieldName: NotRequired[str]
 
 
 class AsyncUploadStorage(Storage):

--- a/packages/ap-storage/alliance_platform/storage/async_uploads/storage/filesystem.py
+++ b/packages/ap-storage/alliance_platform/storage/async_uploads/storage/filesystem.py
@@ -47,7 +47,13 @@ class FileSystemAsyncUploadStorage(FileSystemStorage, AsyncUploadStorage):
         signed_path = self.signer.sign(name)
         query_params = urlencode({"path": signed_path, "field_id": field_id})
         upload_url = reverse("file_system_async_storage_upload") + f"?{query_params}"
-        return {"url": upload_url, "fields": {}}
+        return {
+            "url": upload_url,
+            "fields": {},
+            "method": "POST",
+            "provider": "filesystem",
+            "fileFieldName": "file",
+        }
 
     def generate_download_url(self, key: str, field_id: str, **kwargs):
         signed_path = self.signer.sign(key)

--- a/packages/ap-storage/alliance_platform/storage/async_uploads/storage/s3.py
+++ b/packages/ap-storage/alliance_platform/storage/async_uploads/storage/s3.py
@@ -58,9 +58,15 @@ class S3AsyncUploadStorage(S3Storage, AsyncUploadStorage):
         """
         fields = fields.copy() if fields else {}
         conditions = conditions.copy() if conditions else {}
-        return self.bucket.meta.client.generate_presigned_post(
+        response = self.bucket.meta.client.generate_presigned_post(
             self.bucket_name, name, Fields=fields, Conditions=conditions, ExpiresIn=expire
         )
+        return {
+            **response,
+            "method": "POST",
+            "provider": "s3",
+            "fileFieldName": "file",
+        }
 
     def generate_download_url(
         self, key: str, field_id: str, expire=ap_storage_settings.DOWNLOAD_URL_EXPIRY, **kwargs

--- a/packages/ap-storage/alliance_platform/storage/async_uploads/views/api.py
+++ b/packages/ap-storage/alliance_platform/storage/async_uploads/views/api.py
@@ -7,6 +7,7 @@ from typing import cast
 from alliance_platform.storage.async_uploads.models import AsyncTempFile
 from alliance_platform.storage.async_uploads.registry import AsyncFieldRegistry
 from alliance_platform.storage.async_uploads.registry import default_async_field_registry
+from alliance_platform.storage.async_uploads.storage.base import GenerateUploadUrlResponse
 from allianceutils.util import camelize
 from allianceutils.util import underscoreize
 from django.core.exceptions import BadRequest
@@ -27,6 +28,7 @@ from django.views import View
 def validate_generate_upload_url(data: QueryDict, registry: AsyncFieldRegistry):
     field_id = data.get("field_id")
     filename = data.get("filename")
+    content_type = data.get("content_type")
     params = data.get("params", None)
     instance_id = data.get("instance_id", None)
     errors: dict[str, str] = {}
@@ -48,6 +50,7 @@ def validate_generate_upload_url(data: QueryDict, registry: AsyncFieldRegistry):
     return {
         "field_id": field_id,
         "filename": filename,
+        "content_type": content_type,
         "params": params,
         "instance_id": instance_id,
     }
@@ -59,6 +62,13 @@ class ViewProtocol(Protocol):
 
 class ModelWithDefaultManager(Protocol):
     objects: Manager
+
+
+def normalize_upload_url_response(upload_url: str | GenerateUploadUrlResponse) -> GenerateUploadUrlResponse:
+    # Backward compatibility: custom storages may still return a plain string.
+    if isinstance(upload_url, str):
+        return {"url": upload_url, "fields": {}}
+    return upload_url
 
 
 class GenerateUploadUrlView(View):
@@ -120,22 +130,22 @@ class GenerateUploadUrlView(View):
                 raise BadRequest
 
         temp_file = AsyncTempFile.create_for_field(field, filename)
+        upload_fields = validated_data.get("params") or {}
+        content_type = validated_data.get("content_type")
+        if content_type:
+            upload_fields["Content-Type"] = content_type
         conditions = []
         if field.max_size:
             conditions.append(["content-length-range", 0, field.max_size * 1024 * 1024])
         # this matches any, but is OK because we are signing a single key only anyway which will restrict the type
         conditions.append(["starts-with", "$Content-Type", ""])
-        return JsonResponse(
-            {
-                "uploadUrl": field.storage.generate_upload_url(
-                    temp_file.key,
-                    field_id,
-                    fields=validated_data.get("params"),
-                    conditions=conditions or None,
-                ),
-                "key": temp_file.key,
-            }
+        upload_url = field.storage.generate_upload_url(
+            temp_file.key,
+            field_id,
+            fields=upload_fields or None,
+            conditions=conditions or None,
         )
+        return JsonResponse({"uploadUrl": normalize_upload_url_response(upload_url), "key": temp_file.key})
 
 
 def validate_async_file_download(data: QueryDict, registry: AsyncFieldRegistry):

--- a/packages/ap-storage/alliance_platform/storage/templates/alliance_platform/storage/widgets/async_file_input.html
+++ b/packages/ap-storage/alliance_platform/storage/templates/alliance_platform/storage/widgets/async_file_input.html
@@ -1,0 +1,4 @@
+{% load react %}
+
+{% component "@alliancesoftware/ui/hook-form" "AsyncFileInput" props=widget.attrs|merge_props:extra_widget_props|html_attr_to_jsx name=widget.name default_value=widget.value %}
+{% endcomponent %}

--- a/packages/ap-storage/tests/test_async_field.py
+++ b/packages/ap-storage/tests/test_async_field.py
@@ -5,6 +5,7 @@ import os
 from typing import Literal
 from typing import cast
 from unittest import mock
+from unittest.mock import ANY
 from unittest.mock import patch
 from urllib.parse import urlencode
 
@@ -506,6 +507,22 @@ class AsyncFileFormTestCase(TestCase):
             ),
         )
 
+    def test_file_input_context_sets_generate_upload_url(self):
+        input = AsyncFileInput()
+        field = AsyncFileTestModel._meta.get_field("file1")
+        context = input.get_context(
+            "file1",
+            None,
+            {
+                "async_field_registry": field.async_field_registry,
+            },
+        )
+        self.assertEqual(
+            context["widget"]["attrs"]["generate_upload_url"],
+            reverse(field.async_field_registry.attached_view),
+        )
+        self.assertNotIn("async_field_registry", context["widget"]["attrs"])
+
     def test_file_input_max_len(self):
         class AsyncFileTestModelForm(ModelForm):
             class Meta:
@@ -637,7 +654,9 @@ class GenerateUploadUrlViewTestCase(TestCase):
             assert async_temp_file is not None
             self.assertEqual(async_temp_file.original_filename, "abc.jpg")
             self.assertEqual(data["key"], async_temp_file.key)
-            self.assertEqual(data["uploadUrl"], f"http://signme.com/{async_temp_file.key}")
+            self.assertEqual(
+                data["uploadUrl"], {"url": f"http://signme.com/{async_temp_file.key}", "fields": {}}
+            )
             self.assertEqual(async_temp_file.field_name, "file1")
             self.assertEqual(async_temp_file.content_type.model_class(), AsyncFileTestModel)
             self.assertEqual(async_temp_file.moved_to_location, "")
@@ -663,7 +682,9 @@ class GenerateUploadUrlViewTestCase(TestCase):
             assert async_temp_file is not None
             self.assertEqual(async_temp_file.original_filename, "abc.jpg")
             self.assertEqual(data["key"], async_temp_file.key)
-            self.assertEqual(data["uploadUrl"], f"http://signme.com/{async_temp_file.key}")
+            self.assertEqual(
+                data["uploadUrl"], {"url": f"http://signme.com/{async_temp_file.key}", "fields": {}}
+            )
             self.assertEqual(async_temp_file.field_name, "file1")
             self.assertEqual(async_temp_file.content_type.model_class(), AsyncFileTestModel)
             self.assertEqual(async_temp_file.moved_to_location, "")
@@ -675,6 +696,52 @@ class GenerateUploadUrlViewTestCase(TestCase):
             instance.save()
             self.assertEqual(AsyncTempFile.objects.count(), 1)
             self.assertEqual(AsyncTempFile.objects.filter(moved_to_location="abc.jpg").count(), 1)
+
+    def test_generate_url_includes_upload_metadata(self):
+        with patch("test_alliance_platform_storage.models.User.has_perm", return_value=True):
+            user = User.objects.create(username="test")
+            self.client.force_login(user)
+            with patch(
+                "test_alliance_platform_storage.storage.DummyStorage.generate_upload_url",
+                return_value={
+                    "url": "http://signme.com/file",
+                    "fields": {"key": "file"},
+                    "method": "POST",
+                    "provider": "s3",
+                    "headers": {"x-test-header": "test"},
+                    "fileFieldName": "file",
+                },
+            ):
+                response = self.client.get(self._get_url())
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(
+                    response.json()["uploadUrl"],
+                    {
+                        "url": "http://signme.com/file",
+                        "fields": {"key": "file"},
+                        "method": "POST",
+                        "provider": "s3",
+                        "headers": {"x-test-header": "test"},
+                        "fileFieldName": "file",
+                    },
+                )
+
+    def test_generate_url_passes_content_type_in_upload_fields(self):
+        with patch("test_alliance_platform_storage.models.User.has_perm", return_value=True):
+            user = User.objects.create(username="test")
+            self.client.force_login(user)
+            with patch(
+                "test_alliance_platform_storage.storage.DummyStorage.generate_upload_url",
+                return_value={"url": "http://signme.com/file", "fields": {}},
+            ) as mock_generate_upload_url:
+                response = self.client.get(self._get_url(filename="logo.png") + "&contentType=image%2Fpng")
+                self.assertEqual(response.status_code, 200)
+                mock_generate_upload_url.assert_called_once_with(
+                    ANY,
+                    ANY,
+                    fields={"Content-Type": "image/png"},
+                    conditions=ANY,
+                )
 
 
 class DownloadRedirectViewTestCase(TestCase):


### PR DESCRIPTION
- extend async upload payloads with optional provider/method/header/fileFieldName metadata
- keep generate-upload-url response backward compatible
- add async_file_input.html widget template for AsyncFileInput rendering