### PR TITLE
Add has_changed support to AsyncFileField form field

### DIFF
--- a/.changeset/async-file-has-changed.md
+++ b/.changeset/async-file-has-changed.md
@@ -1,0 +1,5 @@
+---
+"alliance-platform-storage": patch
+---
+
+`AsyncFileField` form field now supports `has_changed`, enabling correct `Form.has_changed()` behavior.

--- a/packages/ap-storage/alliance_platform/storage/async_uploads/forms.py
+++ b/packages/ap-storage/alliance_platform/storage/async_uploads/forms.py
@@ -184,6 +184,17 @@ class AsyncFileField(forms.Field):
             self.validators.append(AsyncFileInputDataLengthValidator(int(max_length)))
         self.validators.append(AsyncFileInputDataValidator())
 
+    def has_changed(self, initial, data):
+        if initial:
+            initial_key = getattr(initial, "name", None) or None
+        else:
+            initial_key = None
+        if data:
+            data_key = data.key
+        else:
+            data_key = None
+        return initial_key != data_key
+
     def widget_attrs(self, widget):
         attrs = super().widget_attrs(widget)
         attrs["async_field_registry"] = self.async_field_registry

--- a/packages/ap-storage/alliance_platform/storage/async_uploads/forms.py
+++ b/packages/ap-storage/alliance_platform/storage/async_uploads/forms.py
@@ -185,12 +185,17 @@ class AsyncFileField(forms.Field):
         self.validators.append(AsyncFileInputDataValidator())
 
     def has_changed(self, initial, data):
+        if self.disabled:
+            return False
         if initial:
             initial_key = getattr(initial, "name", None) or None
         else:
             initial_key = None
-        if data:
+        if isinstance(data, AsyncFileInputData):
             data_key = data.key
+        elif data:
+            # Malformed input (e.g. non-JSON string) — treat as changed
+            return True
         else:
             data_key = None
         return initial_key != data_key

--- a/packages/ap-storage/tests/test_async_field.py
+++ b/packages/ap-storage/tests/test_async_field.py
@@ -595,6 +595,17 @@ class AsyncFileFormTestCase(TestCase):
         initial = FakeFieldFile("")
         self.assertFalse(field.has_changed(initial, None))
 
+        # Malformed input (raw string from failed JSON parse) -> treat as changed
+        self.assertTrue(field.has_changed(None, "not-json"))
+        self.assertTrue(field.has_changed(initial, "not-json"))
+
+        # Disabled field -> never changed
+        field.disabled = True
+        data = AsyncFileInputData(key="async-temp-files/2021/03/03/abc-test.png", name="test.png")
+        self.assertFalse(field.has_changed(None, data))
+        self.assertFalse(field.has_changed(FakeFieldFile("other.png"), data))
+        field.disabled = False
+
 
 class GenerateUploadUrlViewTestCase(TestCase):
     def _get_url(self, instance: AsyncFileTestModel | None = None, filename="abc.jpg"):

--- a/packages/ap-storage/tests/test_async_field.py
+++ b/packages/ap-storage/tests/test_async_field.py
@@ -557,6 +557,44 @@ class AsyncFileFormTestCase(TestCase):
 
         self.assertTrue(storage.generate_temporary_path("test.png").endswith("-test.png"))
 
+    def test_has_changed(self):
+        class AsyncFileTestModelForm(ModelForm):
+            class Meta:
+                model = AsyncFileTestModel
+                fields = ["file1"]
+
+        form = AsyncFileTestModelForm()
+        field = form.fields["file1"]
+
+        class FakeFieldFile:
+            def __init__(self, name):
+                self.name = name
+
+        # No initial, no data -> not changed
+        self.assertFalse(field.has_changed(None, None))
+
+        # No initial, has data -> changed
+        data = AsyncFileInputData(key="async-temp-files/2021/03/03/abc-test.png", name="test.png")
+        self.assertTrue(field.has_changed(None, data))
+
+        # Has initial, no data -> changed (cleared)
+        initial = FakeFieldFile("final/location/test.png")
+        self.assertTrue(field.has_changed(initial, None))
+
+        # Has initial, same key -> not changed
+        initial = FakeFieldFile("final/location/test.png")
+        data = AsyncFileInputData(key="final/location/test.png", name="test.png")
+        self.assertFalse(field.has_changed(initial, data))
+
+        # Has initial, different key -> changed
+        initial = FakeFieldFile("final/location/test.png")
+        data = AsyncFileInputData(key="async-temp-files/2021/03/03/abc-test.png", name="test.png")
+        self.assertTrue(field.has_changed(initial, data))
+
+        # Edge case: empty FieldFile name + no data -> not changed
+        initial = FakeFieldFile("")
+        self.assertFalse(field.has_changed(initial, None))
+
 
 class GenerateUploadUrlViewTestCase(TestCase):
     def _get_url(self, instance: AsyncFileTestModel | None = None, filename="abc.jpg"):


### PR DESCRIPTION
## Summary
This PR adds support for the `has_changed()` method to the `AsyncFileField` form field, enabling proper change detection in Django forms.

## Key Changes
- Implemented `has_changed()` method in `AsyncFileField` that compares initial and submitted file keys
- The method correctly handles all scenarios:
  - No initial value and no data → not changed
  - No initial value but data provided → changed
  - Initial value but no data (cleared) → changed
  - Initial and data with same key → not changed
  - Initial and data with different keys → changed
  - Edge case: empty FieldFile name with no data → not changed
- Added comprehensive test coverage with 6 test cases validating all change detection scenarios

## Implementation Details
The `has_changed()` method extracts the file key from both the initial `FieldFile` object (via its `name` attribute) and the submitted `AsyncFileInputData` object (via its `key` attribute), then compares them for equality. This allows `Form.has_changed()` to correctly detect whether a file field has been modified.

https://claude.ai/code/session_01ETx7aJZxuZAxFkQwBQpmaJ