### PR TITLE
fix(codegen): create CACHE_DIR before writing artifact cache

### DIFF
--- a/.changeset/fix-codegen-cache-dir.md
+++ b/.changeset/fix-codegen-cache-dir.md
@@ -1,0 +1,5 @@
+---
+"alliance-platform-codegen": patch
+---
+
+Fix `FileNotFoundError` when writing the codegen artifact cache if the `CACHE_DIR` (default `.alliance-platform/`) does not yet exist. The directory is now created on `CodegenRegistry` initialisation.

--- a/packages/ap-codegen/alliance_platform/codegen/registry.py
+++ b/packages/ap-codegen/alliance_platform/codegen/registry.py
@@ -176,6 +176,7 @@ class CodegenRegistry:
     def __init__(self):
         self.registrations = []
         self.cache_path = ap_core_settings.CACHE_DIR / "codegen-artifact-cache.json"
+        self.cache_path.parent.mkdir(parents=True, exist_ok=True)
         self.cache = json.loads(self.cache_path.read_text("utf8")) if self.cache_path.exists() else {}
         if not list(self.cache.keys()) == ["version", "entries"]:
             self.cache = {"version": 1, "entries": {}}


### PR DESCRIPTION
Writing the codegen artifact cache failed with FileNotFoundError on a
fresh checkout because the default `.alliance-platform/` directory was
never created. Ensure the parent directory exists when the registry is
constructed.

https://claude.ai/code/session_01Vwmovmzp1C4UfhoixjfAi6