### PR TITLE
fix(ui): include Content component in InlineAlert bundle resources

### DIFF
--- a/.changeset/fix-inlinealert-content-bundling.md
+++ b/.changeset/fix-inlinealert-content-bundling.md
@@ -1,0 +1,5 @@
+---
+"alliance-platform-ui": patch
+---
+
+Fix `InlineAlert` template tag so the `Content` component it wraps plain-string children in is always included in the final frontend bundle. Previously the `Content` import was not statically discoverable and could be omitted from the build, causing the component to fail to render at runtime.

--- a/.changeset/fix-inlinealert-content-bundling.md
+++ b/.changeset/fix-inlinealert-content-bundling.md
@@ -2,4 +2,9 @@
 "alliance-platform-ui": patch
 ---
 
-Fix `InlineAlert` template tag so the `Content` component it wraps plain-string children in is always included in the final frontend bundle. Previously the `Content` import was not statically discoverable and could be omitted from the build, causing the component to fail to render at runtime.
+Fix two latent bundling issues where components referenced dynamically at render time were not statically discoverable, so could be omitted from the production frontend bundle:
+
+- `InlineAlert` wraps plain-string children in a `Content` component.
+- `form_input` wraps the widget in a `LabeledInput` component when `non_standard_widget=True`.
+
+Both dependencies are now registered for bundling at parse time.

--- a/packages/ap-ui/alliance_platform/ui/templatetags/alliance_platform/form.py
+++ b/packages/ap-ui/alliance_platform/ui/templatetags/alliance_platform/form.py
@@ -17,6 +17,7 @@ from django.template import TemplateSyntaxError
 from django.template.base import UNKNOWN_SOURCE
 from django.template.base import FilterExpression
 
+from alliance_platform.frontend.bundler.context import BundlerAsset
 from alliance_platform.frontend.templatetags.react import ComponentNode
 from alliance_platform.frontend.templatetags.react import NestedComponentProp
 from alliance_platform.frontend.templatetags.react import NestedComponentPropAccumulator
@@ -33,7 +34,7 @@ class _NOT_PROVIDED:
     pass
 
 
-class FormInputNode(template.Node):
+class FormInputNode(template.Node, BundlerAsset):
     origin: Origin
     show_valid_state: FilterExpression | bool
     help_text: FilterExpression | str | type[_NOT_PROVIDED]
@@ -52,7 +53,6 @@ class FormInputNode(template.Node):
         non_standard_widget=False,
         **extra_attrs,
     ):
-        self.origin = origin or Origin(UNKNOWN_SOURCE)
         self.show_valid_state = show_valid_state
         self.field = field
         self.help_text = help_text
@@ -60,6 +60,15 @@ class FormInputNode(template.Node):
         self.required = is_required
         self.extra_attrs = extra_attrs or {}
         self.non_standard_widget = non_standard_widget
+        # ``LabeledInput`` is wrapped around the widget at render time when ``non_standard_widget`` is set,
+        # so it is not statically discoverable. Always include it so it is available in the bundle.
+        self._labeled_input_source = get_module_import_source(
+            "@alliancesoftware/ui", "LabeledInput", False, origin
+        )
+        BundlerAsset.__init__(self, origin or Origin(UNKNOWN_SOURCE))
+
+    def get_resources_for_bundling(self):
+        return [self._labeled_input_source.create_frontend_resource(self.bundler)]
 
     def render(self, context: template.Context):
         field: BoundField = self.field.resolve(context)
@@ -105,7 +114,7 @@ class FormInputNode(template.Node):
             if self.non_standard_widget:
                 node = LabeledInputNode(
                     self.origin,
-                    get_module_import_source("@alliancesoftware/ui", "LabeledInput", False, self.origin),
+                    self._labeled_input_source,
                     {
                         **extra_attrs[field.form.renderer.form_input_context_key]["extra_widget_props"],
                         "children": [],

--- a/packages/ap-ui/alliance_platform/ui/templatetags/alliance_platform/inline_alert.py
+++ b/packages/ap-ui/alliance_platform/ui/templatetags/alliance_platform/inline_alert.py
@@ -11,6 +11,17 @@ from .utils import get_module_import_source
 
 
 class InlineAlertNode(ComponentNode):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # ``Content`` is wrapped around plain-string children at render time, so it is not
+        # statically discoverable. Always include it in the bundle so it is available.
+        self._content_source = get_module_import_source("@alliancesoftware/ui", "Content", False, self.origin)
+
+    def get_resources_for_bundling(self):
+        resources = super().get_resources_for_bundling()
+        resources.append(self._content_source.create_frontend_resource(self.bundler))
+        return resources
+
     def resolve_props(self, context: Context) -> ComponentProps:
         props = super().resolve_props(context)
         # If only a string is passed as child then wrap it in a <Content> component
@@ -19,7 +30,7 @@ class InlineAlertNode(ComponentNode):
             props.props["children"] = NestedComponentProp(
                 ComponentNode(
                     self.origin,
-                    get_module_import_source("@alliancesoftware/ui", "Content", False, self.origin),
+                    self._content_source,
                     {"children": children},
                 ),
                 self,


### PR DESCRIPTION
InlineAlert wraps plain-string children in a Content component at render time, but that import was not statically discoverable so it could be omitted from the final frontend bundle. Always include it via get_resources_for_bundling, mirroring the Pagination tag.