### PR TITLE
Fix nested component placeholder collisions with 10+ children

### DIFF
--- a/.changeset/fix-nested-component-placeholder-collision.md
+++ b/.changeset/fix-nested-component-placeholder-collision.md
@@ -2,4 +2,4 @@
 "alliance-platform-frontend": patch
 ---
 
-Fix placeholder collisions in `NestedComponentPropAccumulator` that could corrupt the generated React children when a component contained more than 10 nested components. Placeholder tokens like `__NestedComponentPropAccumulator__prop__1` were a prefix of `__NestedComponentPropAccumulator__prop__10`, so `apply()` could match the wrong placeholder and emit children in the wrong order, leaving raw placeholder strings and dropped/duplicated elements in the output. Placeholders now use a delimited, monotonically-increasing token and `apply()` orders children by their position in the rendered value.
+Fix components with more than 10 nested child components rendering incorrectly. Previously, large component trees (for example a table with many rows, each containing conditional nested components) could render with missing, duplicated, or out-of-order elements, and sometimes leaked raw internal placeholder text into the output. Affected components now render all of their children correctly and in the right order.

--- a/.changeset/fix-nested-component-placeholder-collision.md
+++ b/.changeset/fix-nested-component-placeholder-collision.md
@@ -1,0 +1,5 @@
+---
+"alliance-platform-frontend": patch
+---
+
+Fix placeholder collisions in `NestedComponentPropAccumulator` that could corrupt the generated React children when a component contained more than 10 nested components. Placeholder tokens like `__NestedComponentPropAccumulator__prop__1` were a prefix of `__NestedComponentPropAccumulator__prop__10`, so `apply()` could match the wrong placeholder and emit children in the wrong order, leaving raw placeholder strings and dropped/duplicated elements in the output. Placeholders now use a delimited, monotonically-increasing token and `apply()` orders children by their position in the rendered value.

--- a/packages/ap-frontend/alliance_platform/frontend/templatetags/react.py
+++ b/packages/ap-frontend/alliance_platform/frontend/templatetags/react.py
@@ -295,12 +295,12 @@ class NestedComponentPropAccumulator:
     checks if it's within another component by calling ``NestedComponentPropAccumulator.get_current(context)``. If
     it is it calls ``add`` and returns the string. This will end up rendering something like::
 
-        __NestedComponentPropAccumulator__prop__0 Example
+        __NestedComponentPropAccumulator__prop__0__ Example
 
     Internally ``NestedComponentPropAccumulator`` will store the actual prop::
 
         props = {
-            "__NestedComponentPropAccumulator__prop__0": NestedComponentProp(
+            "__NestedComponentPropAccumulator__prop__0__": NestedComponentProp(
                 ComponentNode("strong", ...),
                 ComponentProps({"children": ["Test"]})
             )
@@ -308,7 +308,7 @@ class NestedComponentPropAccumulator:
 
     Then when ``apply`` is called it will be passed the rendered string::
 
-        "__NestedComponentPropAccumulator__prop__0 Example"
+        "__NestedComponentPropAccumulator__prop__0__ Example"
 
     And process that, returning a list that can be used as children for the component props::
 
@@ -341,6 +341,10 @@ class NestedComponentPropAccumulator:
         self.origin_node = origin_node
         self.context = context
         self.props = {}
+        # Monotonic counter used to generate placeholder ids. Using a dedicated counter (rather
+        # than ``len(self.props)``) means ids are never reused even after props are popped in
+        # ``apply``, avoiding accidental placeholder collisions.
+        self._next_id = 0
 
     @classmethod
     def acquire(cls, context: Context, origin_node: ComponentNode):
@@ -370,7 +374,10 @@ class NestedComponentPropAccumulator:
                 "must be a NestedComponentProp; if you are passing ComponentNode wrap it in ComponentProp first"
             )
 
-        key = f"{self.context_key}__prop__{len(self.props)}"
+        # The trailing ``__`` delimiter is important: without it ``prop__1`` would be a prefix of
+        # ``prop__10`` and ``apply`` could match the wrong placeholder.
+        key = f"{self.context_key}__prop__{self._next_id}__"
+        self._next_id += 1
         self.props[key] = prop
         return key
 
@@ -383,7 +390,7 @@ class NestedComponentPropAccumulator:
 
         For example, given this value::
 
-            "__NestedComponentPropAccumulator__prop__0 Example __NestedComponentPropAccumulator__prop__1 "
+            "__NestedComponentPropAccumulator__prop__0__ Example __NestedComponentPropAccumulator__prop__1__ "
 
         This would be returned (details omitted)::
 
@@ -395,20 +402,25 @@ class NestedComponentPropAccumulator:
         """
         children: list[NestedComponentProp | str] = []
         if self.props:
-            prev_index = 0
-            found_placeholders = set()
+            # Collect each placeholder that appears in ``value`` along with its position so we can
+            # emit children in the order they actually appear in the rendered string (which is not
+            # necessarily the order they were added to ``self.props``).
+            found = []
             for placeholder, prop in self.props.items():
                 index = value.find(placeholder)
                 if index == -1:
                     continue
+                found.append((index, placeholder, prop))
+            found.sort(key=lambda item: item[0])
+
+            prev_index = 0
+            for index, placeholder, prop in found:
                 if index > prev_index:
                     part = value[prev_index:index]
                     if part:
                         children.append(part)
                 children.append(prop)
                 prev_index = index + len(placeholder)
-                found_placeholders.add(placeholder)
-            for placeholder in found_placeholders:
                 self.props.pop(placeholder)
             value = value[prev_index:]
         if value:

--- a/packages/ap-frontend/tests/test_bundler_templatetags.py
+++ b/packages/ap-frontend/tests/test_bundler_templatetags.py
@@ -17,6 +17,8 @@ from alliance_platform.frontend.html_parser import convert_html_string
 from alliance_platform.frontend.templatetags.react import ComponentNode
 from alliance_platform.frontend.templatetags.react import ComponentProps
 from alliance_platform.frontend.templatetags.react import ComponentSourceCodeGenerator
+from alliance_platform.frontend.templatetags.react import NestedComponentProp
+from alliance_platform.frontend.templatetags.react import NestedComponentPropAccumulator
 from django.template import Context
 from django.template import Origin
 from django.template import Template
@@ -1350,3 +1352,75 @@ class TestComponentTemplateTagOutput(SimpleTestCase):
             """<div><strong><span><em>test</em></span></strong></div>""",
             value=mark_safe("<em>test</em>"),
         )
+
+    def test_many_nested_conditional_components(self):
+        """Regression test for placeholder prefix collisions in NestedComponentPropAccumulator.
+
+        With more than 10 nested components the accumulator generates placeholders like
+        ``...__prop__1`` and ``...__prop__10``. Because ``prop__1`` is a prefix of ``prop__10``
+        the ``apply`` method could match the wrong placeholder, dropping/duplicating children
+        and leaving raw placeholder strings in the output. See
+        ``TestNestedComponentPropAccumulator`` for the focused unit tests.
+        """
+        rows = list(range(1, 21))
+        tree = self._get_debug_tree(
+            "{% component 'div' %}"
+            "{% for n in rows %}"
+            "{% component 'span' %}"
+            "{% if n %}{% component 'strong' %}{{ n }}{% endcomponent %}"
+            "{% else %}{% component 'em' %}none{% endcomponent %}{% endif %}"
+            "{% endcomponent %}"
+            "{% endfor %}"
+            "{% endcomponent %}",
+            rows=rows,
+        )
+        # No raw accumulator placeholder should leak into the generated tree
+        self.assertNotIn("__NestedComponentPropAccumulator", tree)
+        # Every row must be preserved (each row renders one <strong>{{ n }}</strong>)
+        self.assertEqual(tree.count("<strong>"), len(rows))
+        for n in rows:
+            self.assertIn(f"<strong>{n}</strong>", tree)
+
+
+class TestNestedComponentPropAccumulator(SimpleTestCase):
+    """Focused unit tests for ``NestedComponentPropAccumulator`` placeholder handling."""
+
+    def _make_accumulator(self):
+        return NestedComponentPropAccumulator(Context(), mock.Mock(spec=ComponentNode))
+
+    def test_apply_does_not_match_placeholder_prefix(self):
+        """A placeholder must not be matched as a prefix of a longer placeholder.
+
+        ``prop__1`` must not match inside ``prop__10``.
+        """
+        accumulator = self._make_accumulator()
+        props = [mock.Mock(spec=NestedComponentProp) for _ in range(11)]
+        keys = [accumulator.add(prop) for prop in props]
+        # Sanity check: the id 1 placeholder is not a prefix of the id 10 placeholder
+        self.assertFalse(keys[10].startswith(keys[1]))
+
+        # Render a value that only contains the placeholder for props[10]
+        result = accumulator.apply(f"before {keys[10]} after")
+        self.assertEqual(result, ["before ", props[10], " after"])
+
+    def test_apply_orders_children_by_occurrence(self):
+        """Children must be returned in the order they appear in the rendered value."""
+        accumulator = self._make_accumulator()
+        first = mock.Mock(spec=NestedComponentProp)
+        second = mock.Mock(spec=NestedComponentProp)
+        key_first = accumulator.add(first)
+        key_second = accumulator.add(second)
+
+        # The rendered value has ``second`` appearing before ``first``
+        result = accumulator.apply(f"{key_second} middle {key_first}")
+        self.assertEqual(result, [second, " middle ", first])
+
+    def test_add_generates_unique_non_colliding_keys(self):
+        accumulator = self._make_accumulator()
+        keys = [accumulator.add(mock.Mock(spec=NestedComponentProp)) for _ in range(12)]
+        self.assertEqual(len(set(keys)), len(keys))
+        # No key may be a prefix of another key
+        for outer in keys:
+            for inner in keys:
+                if outer is not inner:
+                    self.assertFalse(inner.startswith(outer))

--- a/packages/ap-ui/alliance_platform/ui/templatetags/alliance_platform/form.py
+++ b/packages/ap-ui/alliance_platform/ui/templatetags/alliance_platform/form.py
@@ -186,31 +186,31 @@ class NestedComponentFormWidgetNode(Node):
 
         ``widget_html`` will be:
 
-            __NestedComponentPropAccumulator__prop__0
+            __NestedComponentPropAccumulator__prop__0__
             Plain text <strong>Nested HTML</strong> More text <span>Extra</span>
-            __NestedComponentPropAccumulator__prop__1
+            __NestedComponentPropAccumulator__prop__1__
             End
 
         ``convert_html_string`` will return:
 
             [
-              '__NestedComponentPropAccumulator__prop__0\nPlain text ',
+              '__NestedComponentPropAccumulator__prop__0__\nPlain text ',
               ComponentNode(CommonComponentSource(name='strong'), {'children': ['Nested HTML']}),
               ' More text ',
               ComponentNode(CommonComponentSource(name='span'), {'children': ['Extra']}),
-              '\n__NestedComponentPropAccumulator__prop__1\nEnd'
+              '\n__NestedComponentPropAccumulator__prop__1__\nEnd'
             ]
 
         Next we replace any `ComponentNode` with a placeholder (__form_widget_placeholder(0)__) using ``_replace_nodes_with_str``
         which generates a string like:
 
-            __NestedComponentPropAccumulator__prop__0
+            __NestedComponentPropAccumulator__prop__0__
             Plain text __form_widget_placeholder(0)__ More text __form_widget_placeholder(1)__
-            __NestedComponentPropAccumulator__prop__1
+            __NestedComponentPropAccumulator__prop__1__
             End
 
         This gets passed through ``temp_accumulator.apply`` which will replace any of the placeholders from first
-        pass ("__NestedComponentPropAccumulator__prop__0" in the example). This results in:
+        pass ("__NestedComponentPropAccumulator__prop__0__" in the example). This results in:
 
             [
                 NestedComponentProp(ImportComponentSource(TextInput), ComponentProps({..})),
@@ -226,9 +226,9 @@ class NestedComponentFormWidgetNode(Node):
         in place of the original. This is repeated until all placeholders are replaced. This gives us a final
         string like:
 
-            __NestedComponentPropAccumulator__prop__0
-            Plain text __NestedComponentPropAccumulator__prop__1 More text __NestedComponentPropAccumulator__prop__2
-            __NestedComponentPropAccumulator__prop__3
+            __NestedComponentPropAccumulator__prop__0__
+            Plain text __NestedComponentPropAccumulator__prop__1__ More text __NestedComponentPropAccumulator__prop__2__
+            __NestedComponentPropAccumulator__prop__3__
             End
 
         This is what we return, and the parent component will replace any of the remaining placeholders as part of


### PR DESCRIPTION
## Summary
Fixed a bug in `NestedComponentPropAccumulator` that caused incorrect rendering when components had more than 10 nested child components. The issue was caused by placeholder string prefix collisions (e.g., `prop__1` matching inside `prop__10`), which could result in missing, duplicated, or out-of-order elements, and sometimes leaked raw placeholder text into the output.

## Key Changes
- **Placeholder format**: Changed placeholder key format from `__prop__{id}` to `__prop__{id}__` (added trailing delimiter) to prevent prefix collisions
- **ID generation**: Replaced using `len(self.props)` with a dedicated monotonic `_next_id` counter to ensure IDs are never reused, even after props are popped during `apply()`
- **Placeholder matching logic**: Refactored `apply()` method to:
  - Collect all found placeholders with their positions before processing
  - Sort by position to maintain correct child order
  - Use a single pass to emit children in the order they appear in the rendered string
  - This prevents the wrong placeholder from being matched when one is a prefix of another

## Implementation Details
- The trailing `__` delimiter is critical: without it, `prop__1` would be a prefix of `prop__10` and the string search could match the wrong placeholder
- The monotonic counter approach ensures placeholder IDs are globally unique within an accumulator instance, preventing accidental collisions even in complex nested scenarios
- Children are now explicitly ordered by their occurrence in the rendered value, not by the order they were added to the accumulator

## Testing
- Added regression test `test_many_nested_conditional_components` covering 20 nested components with conditional rendering
- Added focused unit tests in `TestNestedComponentPropAccumulator` covering:
  - Placeholder prefix collision prevention
  - Child ordering by occurrence
  - Unique non-colliding key generation

https://claude.ai/code/session_01Av5hZeJaM4EqM6VmZMTHN7