### PR TITLE
Add static HTML dispatcher renderers for the Alliance UI table components

### DIFF
--- a/.changeset/brave-tables-render.md
+++ b/.changeset/brave-tables-render.md
@@ -1,0 +1,5 @@
+---
+"alliance-platform-ui": patch
+---
+
+Add static HTML dispatcher renderers for the Alliance UI table components, available through `{% ui "table" %}`, `{% ui "table_header" %}`, `{% ui "table_body" %}`, `{% ui "table_column" %}`, `{% ui "table_row" %}` and `{% ui "table_cell" %}`. These mirror the `@alliancesoftware/ui` `Table` markup (visual classes, state data attributes, sort icons, empty state, header/footer) without any JavaScript runtime, and support backend-driven sorting through plain links that update a query parameter (matching the `useTableSorter`/`ColumnHeaderLink` toggle semantics, including `sort_mode`/`sort_behavior`). Row selection, client-side sorting and the interactive ARIA grid behaviour are intentionally unsupported; the React-backed `{% Table %}` tags remain for those cases.

--- a/.github/alliance-platform-js-ref
+++ b/.github/alliance-platform-js-ref
@@ -1,0 +1,1 @@
+codex/smart-orientation-attach-runtime

--- a/.github/workflows/ap-ui-fixture-drift.yml
+++ b/.github/workflows/ap-ui-fixture-drift.yml
@@ -4,7 +4,15 @@ on:
   pull_request:
     paths:
       - "packages/ap-ui/tests/fixtures/ui_html_*_parity.json"
+      - "packages/ap-ui/scripts/**"
+      - ".github/alliance-platform-js-ref"
+      - ".github/workflows/ap-ui-fixture-drift.yml"
   workflow_dispatch:
+    inputs:
+      js_ref:
+        description: "alliance-platform-js ref to regenerate fixtures against (overrides .github/alliance-platform-js-ref)"
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -19,12 +27,26 @@ jobs:
       - name: Checkout alliance-platform-py
         uses: actions/checkout@v4
 
+      # Cross-repo changes can be tested before the alliance-platform-js side merges by pinning
+      # the ref in .github/alliance-platform-js-ref (reset it to "main" once the JS branch
+      # merges), or by passing the js_ref input on manual runs.
+      - name: Resolve alliance-platform-js ref
+        id: js-ref
+        run: |
+          ref="${{ inputs.js_ref }}"
+          if [[ -z "$ref" && -f .github/alliance-platform-js-ref ]]; then
+            ref="$(head -n1 .github/alliance-platform-js-ref | tr -d '[:space:]')"
+          fi
+          ref="${ref:-main}"
+          echo "Using alliance-platform-js ref: $ref"
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+
       - name: Checkout alliance-platform-js
         uses: actions/checkout@v4
         with:
           repository: AllianceSoftware/alliance-platform-js
           path: alliance-platform-js
-          ref: main
+          ref: ${{ steps.js-ref.outputs.ref }}
           ssh-key: ${{ secrets.ALLIANCE_PLATFORM_JS_DEPLOY_KEY }}
           persist-credentials: false
 
@@ -51,4 +73,5 @@ jobs:
             packages/ap-ui/tests/fixtures/ui_html_button_group_parity.json \
             packages/ap-ui/tests/fixtures/ui_html_text_input_parity.json \
             packages/ap-ui/tests/fixtures/ui_html_number_input_parity.json \
-            packages/ap-ui/tests/fixtures/ui_html_text_area_parity.json
+            packages/ap-ui/tests/fixtures/ui_html_text_area_parity.json \
+            packages/ap-ui/tests/fixtures/ui_html_table_parity.json

--- a/Justfile
+++ b/Justfile
@@ -213,7 +213,8 @@ check-html-ui-parity-fixtures js_repo="../alliance-platform-js":
         packages/ap-ui/tests/fixtures/ui_html_button_group_parity.json \
         packages/ap-ui/tests/fixtures/ui_html_text_input_parity.json \
         packages/ap-ui/tests/fixtures/ui_html_number_input_parity.json \
-        packages/ap-ui/tests/fixtures/ui_html_text_area_parity.json
+        packages/ap-ui/tests/fixtures/ui_html_text_area_parity.json \
+        packages/ap-ui/tests/fixtures/ui_html_table_parity.json
 
 # Build docs and watch for changes
 docs-watch:

--- a/packages/ap-ui/DEVELOPMENT.md
+++ b/packages/ap-ui/DEVELOPMENT.md
@@ -99,6 +99,65 @@ intentional extensions, so they will not show up as parity failures:
 - **Boolean attributes**: React SSR renders `disabled=""`/`readonly=""`; the Python renderer emits
   bare `disabled`/`readonly`. The parity normalizer treats these as equivalent (they are in HTML).
 
+## Table components (`table`, `table_header`, `table_body`, `table_column`, `table_row`, `table_cell`)
+
+The static table renderers live in
+`alliance_platform/ui/templatetags/alliance_platform/html_components/components/table.py` and
+mirror `@alliancesoftware/ui`'s `Table.tsx` for the read-only CRUD list case. Sorting is rendered
+as plain `<a href>` links that update a backend query parameter, mirroring `ColumnHeaderLink.tsx` /
+`useTableSorter.ts` (direction cycle: unsorted → ascending → descending → off).
+
+### Cross-component render state
+
+The components coordinate through a `TableRenderState` stack stored in `context.render_context`
+(`_TABLE_STATE_KEY`), pushed by `table` around its children via the
+`render_children_for_component()` hook on the base renderer (which, unlike `render_children()`,
+receives the resolved props). `render_context` is shared across `{% include %}` — including
+`only` — within one template render, and a stack supports tables nested inside cells:
+
+1. `table` builds the state from its props (sort order/mode/behaviour, query param, empty state)
+   and pushes it while children render.
+2. Each `table_column` appends its `TableColumnState` (key, align, row-header flag, sort state)
+   in render order.
+3. Each `table_row` resets `current_row_cell_index` to 0 around its children and increments
+   `row_count` (so `table_body` can render the default empty state only when no rows rendered).
+4. Each `table_cell` consumes the column state at the current index to inherit alignment and
+   row-header status, advancing the index by the cell's `colSpan` so later cells stay aligned.
+
+Components rendered outside their expected parent warn and render fallback markup rather than
+failing (CRUD pages should not 500 because of a conditional cell); rows with more cells than
+registered columns warn once per table.
+
+### Intentionally unsupported React Table features
+
+Row selection (`selectionMode`, `selectedKeys`, checkboxes, `isSelected`), client-side sorting
+(`onSortChange`, `sortFunction`, `defaultSortOrder`), collection render props (`items`,
+`columns`), `columnHeaderElementType`, nested/grouped columns, and all keyboard grid/focus
+behaviour (including `mode="edit"` semantics — only the `data-mode` attribute is rendered). These
+warn and are dropped so templates never render interactive-looking state with no behaviour behind
+it.
+
+### Native semantics vs the React ARIA grid
+
+The React table is an interactive ARIA grid (grid roles, tab indexes, focus management). The
+static renderer intentionally keeps native table semantics instead: no grid roles or tab indexes,
+`scope="col"` and `aria-sort` on `<th>` header cells (direction when sorted, `"none"` when
+sortable-but-unsorted), and row-header cells as `<td role="rowheader">` rather than
+`<th scope="row">` so browser default `<th>` styling cannot diverge visually from React. The
+fixture generator's `normalizeTableComponentHtml()` reconciles these documented differences; see
+the comments there for the full list (grid roles, `data-collection`/`data-key` bookkeeping,
+absolute vs relative sort hrefs, CSS var hashes in `style`).
+
+Two React quirks worth knowing when comparing against `Table.tsx`: the user `className` is merged
+*before* the default classes on `<th>`/`<tr>` (mergeProps ordering) but *after* them on `<td>`
+and the wrapper, and `align="center"` applies `alignCenter` to body cells only — headers just get
+`data-align="center"` (the static renderer matches both).
+
+Sortable-column fixtures record the URL the React SSR render happened at in `meta.current_url`
+(the generator exposes it via `globalSsrContext.currentUrl`, which `ColumnHeaderLink` reads during
+SSR); the Python parity test builds a `RequestFactory` request for the same URL. Regenerate the
+table fixtures with `just sync-html-ui-parity-fixtures ../alliance-platform-js table`.
+
 ## HTML parity fixture workflow
 
 The fixture generator depends on `@alliancesoftware/ui` TypeScript sources, so it must run through the `alliance-platform-js` runtime context.
@@ -134,6 +193,19 @@ The cross-repo fixture drift workflow is defined in:
 - `.github/workflows/ap-ui-fixture-drift.yml`
 
 It checks out both `alliance-platform-py` and `alliance-platform-js`, regenerates the fixtures, and fails if fixture files changed.
+
+### Testing against an unmerged alliance-platform-js branch
+
+By default the workflow regenerates fixtures against alliance-platform-js `main`. When a change
+here depends on an unmerged alliance-platform-js branch (e.g. fixtures were regenerated against a
+JS fix), pin the ref in:
+
+- `.github/alliance-platform-js-ref` — single line containing the branch/tag/SHA to check out.
+
+Commit the pin with your PR so CI tests the pair together, and reset the file to `main` once the
+JS branch merges (until then, `main` runs of the drift check will use the pinned ref, so don't
+leave stale pins behind). Manual runs can override the ref with the `js_ref` input on
+`workflow_dispatch` without touching the file.
 
 For private `alliance-platform-js` access in GitHub Actions, configure:
 

--- a/packages/ap-ui/alliance_platform/ui/forms/renderers.py
+++ b/packages/ap-ui/alliance_platform/ui/forms/renderers.py
@@ -30,6 +30,19 @@ class FormInputContextRenderer(TemplatesSetting):
 
     form_input_context_key = form_input_context_key
 
+    def _add_missing_describedby(self, attrs, extra_context):
+        """Mirror Django 5's help-text aria wiring when running on Django 4.2."""
+        if attrs.get("aria-describedby") or "id" not in attrs:
+            return
+        if not extra_context.get("extra_widget_props", {}).get("description"):
+            return
+
+        # Django 5 adds this in BoundField.build_widget_attrs(), before the id is
+        # added. Reorder the dict so generated JSX debug output remains stable.
+        field_id = attrs.pop("id")
+        attrs["aria-describedby"] = f"{field_id}_helptext"
+        attrs["id"] = field_id
+
     def render(self, template_name, context, request=None):
         from alliance_platform.frontend.templatetags.react import NestedComponentPropAccumulator
 
@@ -46,5 +59,6 @@ class FormInputContextRenderer(TemplatesSetting):
             # usage with merge_props etc easier
             if "extra_widget_props" not in extra_context:
                 extra_context["extra_widget_props"] = {}
+            self._add_missing_describedby(context["widget"]["attrs"], extra_context)
             context.update(extra_context)
         return super().render(template_name, context, request)

--- a/packages/ap-ui/alliance_platform/ui/templatetags/alliance_platform/html_components/base.py
+++ b/packages/ap-ui/alliance_platform/ui/templatetags/alliance_platform/html_components/base.py
@@ -50,6 +50,16 @@ _REACT_ATTR_TO_HTML_ATTR = {
 
 _CAMEL_CASE_SPLIT_RE = re.compile(r"([a-z0-9])([A-Z])")
 
+#: Stylesheet for the ``@alliancesoftware/icons`` Icon component, required whenever
+#: :meth:`BaseHtmlUIComponentRenderer.render_icon` output may be rendered.
+ICON_STYLE_PATH = "@alliancesoftware/icons/Icon.css.ts"
+
+# Static SVG markup matching the icons rendered by the React components
+# (see @alliancesoftware/icons/outlined/*.tsx). Width/height are set inline by the Icon
+# component so icons have a size before stylesheets load.
+_SVG_ATTRS = 'width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false"'
+_SVG_PATH_ATTRS = 'stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"'
+
 # Extra key adaptations applied to bulk ``props`` dicts (after the standard HTML -> React attribute
 # name conversion). Bulk props typically come from HTML attribute dicts such as Django's
 # ``widget.attrs``, where boolean state is expressed with the plain HTML attribute names rather
@@ -149,7 +159,7 @@ class BaseHtmlUIComponentRenderer(template.Node, BundlerAsset):
         self._queue_resources()
         props = self.resolve_props(context)
         props = self._merge_slot_props(context, props)
-        children_html = self.render_children(context)
+        children_html = self.render_children_for_component(context, props)
         rendered = self.render_component(context, props, children_html)
         if self.target_var:
             context[self.target_var] = rendered
@@ -219,6 +229,15 @@ class BaseHtmlUIComponentRenderer(template.Node, BundlerAsset):
         if isinstance(value, NodeList):
             return value.render(context)
         return value
+
+    def render_children_for_component(self, context: Context, props: dict[str, Any]) -> str:
+        """Render children during the main :meth:`render` flow.
+
+        Unlike :meth:`render_children` this receives the resolved props, so renderers that need to
+        share state with their children (e.g. the table components) can push that state around the
+        children render based on the props.
+        """
+        return self.render_children(context)
 
     def render_children(
         self,
@@ -326,6 +345,22 @@ class BaseHtmlUIComponentRenderer(template.Node, BundlerAsset):
             if isinstance(variant_class, str) and variant_class:
                 classes.append(variant_class)
         return classes
+
+    def render_icon(self, svg_path: str, size: str, extra_class_names: list[str] | None = None) -> str:
+        """Render the static markup produced by ``@alliancesoftware/icons`` for an outlined icon."""
+        icon_styles = self.resolve_vanilla_extract_mapping(ICON_STYLE_PATH)
+        class_name = self.join_classes(
+            self.get_style_class(icon_styles, "icon"),
+            self.get_nested_style_class(icon_styles, "variants", "plain"),
+            self.get_nested_style_class(icon_styles, "sizes", size),
+            *(extra_class_names or []),
+        )
+        return (
+            f'<span role="img" aria-hidden="true" class="{conditional_escape(class_name)}">'
+            f"<svg {_SVG_ATTRS}>"
+            f'<path d="{svg_path}" {_SVG_PATH_ATTRS}></path>'
+            "</svg></span>"
+        )
 
     def build_attrs_string(self, attrs: dict[str, Any]) -> str:
         return build_attrs_string(attrs)

--- a/packages/ap-ui/alliance_platform/ui/templatetags/alliance_platform/html_components/components/input.py
+++ b/packages/ap-ui/alliance_platform/ui/templatetags/alliance_platform/html_components/components/input.py
@@ -14,6 +14,7 @@ from django.utils.safestring import mark_safe
 
 from alliance_platform.frontend.bundler.frontend_resource import FrontendResource
 
+from ..base import ICON_STYLE_PATH
 from ..base import BaseHtmlUIComponentRenderer
 from ..content import has_renderable_content
 from ..content import is_rich_content_value
@@ -36,17 +37,11 @@ _LABELED_INPUT_STYLE_PATH = "@alliancesoftware/ui/components/form/LabeledInput.c
 _LABEL_STYLE_PATH = "@alliancesoftware/ui/components/form/Label.css.ts"
 _FORM_SECTION_STYLE_PATH = "@alliancesoftware/ui/components/form/FormSection.css.ts"
 _FOCUS_RING_STYLE_PATH = "@alliancesoftware/ui/styles/base/focusRing.css.ts"
-_ICON_STYLE_PATH = "@alliancesoftware/icons/Icon.css.ts"
 _NUMBER_INPUT_STYLE_PATH = "@alliancesoftware/ui/components/number-input/NumberInput.css.ts"
 
 # Key used in ``context.render_context`` to keep generated ids unique within a template render.
 _HTML_ID_COUNTER_KEY = "alliance_platform_ui_html_id_counter"
 
-# Static SVG markup matching the icons rendered by the React components
-# (see @alliancesoftware/icons/outlined/*.tsx). Width/height are set inline by the Icon
-# component so icons have a size before stylesheets load.
-_SVG_ATTRS = 'width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false"'
-_SVG_PATH_ATTRS = 'stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"'
 _ALERT_CIRCLE_SVG_PATH = (
     "M12 8V12M12 16H12.01M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 "
     "6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12Z"
@@ -337,22 +332,6 @@ class UILabeledInputRendererMixin(_LabeledInputMixinBase):
             return self._render_tag("div", attrs, content)
         return ""
 
-    def render_icon(self, svg_path: str, size: str, extra_class_names: list[str] | None = None) -> str:
-        """Render the static markup produced by ``@alliancesoftware/icons`` for an outlined icon."""
-        icon_styles = self.resolve_vanilla_extract_mapping(_ICON_STYLE_PATH)
-        class_name = self.join_classes(
-            self.get_style_class(icon_styles, "icon"),
-            self.get_nested_style_class(icon_styles, "variants", "plain"),
-            self.get_nested_style_class(icon_styles, "sizes", size),
-            *(extra_class_names or []),
-        )
-        return (
-            f'<span role="img" aria-hidden="true" class="{conditional_escape(class_name)}">'
-            f"<svg {_SVG_ATTRS}>"
-            f'<path d="{svg_path}" {_SVG_PATH_ATTRS}></path>'
-            "</svg></span>"
-        )
-
 
 class UITextInputBaseRenderer(UILabeledInputRendererMixin, BaseHtmlUIComponentRenderer):
     """Shared rendering for text-like inputs, mirroring ``TextInputBase.tsx``."""
@@ -406,7 +385,7 @@ class UITextInputBaseRenderer(UILabeledInputRendererMixin, BaseHtmlUIComponentRe
             self.resolve_frontend_resource(_LABEL_STYLE_PATH),
             self.resolve_frontend_resource(_FORM_SECTION_STYLE_PATH),
             self.resolve_frontend_resource(_FOCUS_RING_STYLE_PATH),
-            self.resolve_frontend_resource(_ICON_STYLE_PATH),
+            self.resolve_frontend_resource(ICON_STYLE_PATH),
         ]
 
     def render_component(self, context: Context, props: dict[str, Any], children_html: str) -> str:

--- a/packages/ap-ui/alliance_platform/ui/templatetags/alliance_platform/html_components/components/table.py
+++ b/packages/ap-ui/alliance_platform/ui/templatetags/alliance_platform/html_components/components/table.py
@@ -1,0 +1,789 @@
+"""Static HTML renderers for the Alliance UI table components.
+
+These mirror ``@alliancesoftware/ui``'s ``Table`` (see ``components/table/Table.tsx``) for the
+read-only CRUD list case: the same markup structure, vanilla-extract classes and state data
+attributes, but no JavaScript runtime. Sorting is expressed as plain links that update a backend
+query parameter (mirroring ``ColumnHeaderLink.tsx`` / ``useTableSorter.ts``); row selection,
+client-side sorting and the React Aria keyboard grid behaviour are intentionally unsupported.
+
+Because the React table is an interactive ARIA grid and the static table is not, native table
+semantics are preferred: no grid roles or tab indexes are rendered, ``aria-sort``/``scope="col"``
+are set on header cells, and row-header cells render as ``<td role="rowheader">`` (rather than
+``<th scope="row">``) so browser default ``<th>`` styling cannot diverge from the React output.
+
+Cross-component coordination (column metadata inherited by body cells, row/cell counting for the
+empty state) is done through a :class:`TableRenderState` stack stored in
+``context.render_context``, which survives ``{% include %}`` (including ``only``) within a single
+template render.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+from dataclasses import field
+from decimal import Decimal
+import re
+from typing import Any
+from typing import Iterator
+from typing import Literal
+from typing import Mapping
+import warnings
+
+from django.template import Context
+from django.utils.functional import Promise
+from django.utils.html import conditional_escape
+from django.utils.safestring import mark_safe
+
+from alliance_platform.frontend.bundler.frontend_resource import FrontendResource
+
+from ..base import ICON_STYLE_PATH
+from ..base import BaseHtmlUIComponentRenderer
+from ..base import style_dict_to_string
+from ..base import to_html_attr_name
+from ..content import render_content
+
+_TABLE_STYLE_PATH = "@alliancesoftware/ui/components/table/Table.css.ts"
+
+# Key used in ``context.render_context`` for the stack of in-progress table renders.
+_TABLE_STATE_KEY = "alliance_platform_ui_table_state"
+
+VALID_SORT_MODES = ("single", "multiple")
+VALID_SORT_BEHAVIORS = ("toggle", "replace")
+VALID_TABLE_MODES = ("default", "edit")
+VALID_ALIGNMENTS = ("start", "center", "end")
+VALID_SORT_DIRECTIONS = ("ascending", "descending")
+
+DEFAULT_SORT_QUERY_PARAM = "ordering"
+
+# SVG paths matching @alliancesoftware/icons/outlined/Arrow{Up,Down}Outlined.tsx
+_ARROW_UP_SVG_PATH = "M12 19V5M12 5L5 12M12 5L19 12"
+_ARROW_DOWN_SVG_PATH = "M12 5V19M12 19L19 12M12 19L5 12"
+
+# Inline styles rendered by react-aria's VisuallyHidden, used for hideHeader content. There is no
+# shared visually-hidden class in the design system so the same inline convention is used here.
+_VISUALLY_HIDDEN_STYLE = (
+    "border: 0; clip: rect(0 0 0 0); clip-path: inset(50%); height: 1px; margin: -1px; "
+    "overflow: hidden; padding: 0; position: absolute; width: 1px; white-space: nowrap"
+)
+
+# Matches event handler props in any of the forms they can reach us in after prop normalization
+# (onClick, onclick, on_click -> onClick). These must never be rendered: a string value would
+# become a live inline event handler attribute, which React never renders.
+_EVENT_HANDLER_PROP_RE = re.compile(r"^on[A-Za-z]")
+
+_EVENT_HANDLER_REASON = "event handlers are not supported by static table components"
+_SELECTION_REASON = "row selection is not supported by static table components yet"
+_SORT_CALLBACK_REASON = "client-side sort callbacks are not supported by static table components"
+_COLLECTION_REASON = "collection render props are not supported by static table components"
+_NESTED_COLUMNS_REASON = "nested/grouped columns are not supported by static table components"
+
+_TABLE_UNSUPPORTED_PROPS: Mapping[str, str] = {
+    "selectionMode": _SELECTION_REASON,
+    "selectionBehavior": _SELECTION_REASON,
+    "selectedKeys": _SELECTION_REASON,
+    "defaultSelectedKeys": _SELECTION_REASON,
+    "onSelectionChange": _SELECTION_REASON,
+    "showSelectionCheckboxes": _SELECTION_REASON,
+    "disabledKeys": _SELECTION_REASON,
+    "disabledBehavior": _SELECTION_REASON,
+    "onSortChange": _SORT_CALLBACK_REASON,
+    "sortFunction": _SORT_CALLBACK_REASON,
+    "defaultSortOrder": "uncontrolled sort state is not supported by static table components; pass sortOrder",
+    "items": _COLLECTION_REASON,
+    "columns": _COLLECTION_REASON,
+    "columnHeaderElementType": (
+        "custom column header element types are not supported by static table components"
+    ),
+}
+
+
+def _is_scalar_prop_value(value: Any) -> bool:
+    return isinstance(value, (str, int, float, bool, Decimal, Promise)) or value is None
+
+
+def _pixelify(value: Any) -> str:
+    """Append ``px`` to bare numbers, matching the React ``pixelify('width', value)`` helper."""
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        if value == 0:
+            return "0"
+        if isinstance(value, float) and value.is_integer():
+            value = int(value)
+        return f"{value}px"
+    return str(value)
+
+
+def _coerce_int(value: Any) -> int | None:
+    try:
+        if isinstance(value, bool):
+            return None
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+@dataclass
+class TableSortDescriptor:
+    column: str
+    direction: Literal["ascending", "descending"]
+
+
+@dataclass
+class TableColumnState:
+    key: str | None
+    align: Literal["start", "center", "end"] | None
+    is_row_header: bool
+    allows_sorting: bool
+    sort_direction: Literal["ascending", "descending"] | None
+    sort_position: int | None
+    show_sort_position: bool
+
+
+@dataclass
+class TableRenderState:
+    sort_order: list[TableSortDescriptor]
+    sort_mode: Literal["single", "multiple"]
+    sort_behavior: Literal["toggle", "replace"]
+    sort_query_param: str
+    #: rendered empty state content, or None when the empty state is disabled
+    empty_state_html: str | None
+    columns: list[TableColumnState] = field(default_factory=list)
+    row_count: int = 0
+    #: index of the next cell within the current row, or None outside a row
+    current_row_cell_index: int | None = None
+    #: True once any column explicitly passed isRowHeader=True; when False the first column is
+    #: the row header by default (matching the React Table)
+    has_explicit_row_header: bool = False
+    #: used to warn once per table when rows contain more cells than registered columns
+    warned_extra_cells: bool = False
+    #: row_count snapshots pushed when a table_body starts rendering and popped when it finishes,
+    #: so it can tell whether any of its own rows rendered. Kept here (rather than on the renderer)
+    #: because renderer instances are template nodes and must not carry per-render state.
+    body_start_row_counts: list[int] = field(default_factory=list)
+
+
+def get_current_table_state(context: Context) -> TableRenderState | None:
+    stack = context.render_context.get(_TABLE_STATE_KEY)
+    if not stack:
+        return None
+    return stack[-1]
+
+
+@contextmanager
+def _push_table_state(context: Context, state: TableRenderState) -> Iterator[None]:
+    stack = context.render_context.get(_TABLE_STATE_KEY)
+    if stack is None:
+        stack = []
+        context.render_context[_TABLE_STATE_KEY] = stack
+    stack.append(state)
+    try:
+        yield
+    finally:
+        stack.pop()
+
+
+class UITableComponentRendererBase(BaseHtmlUIComponentRenderer):
+    """Shared prop validation for the static table component renderers.
+
+    Mirrors the input renderer policy: event handler props and React-only props warn and are
+    dropped, unknown props warn rather than rendering arbitrary attributes, and ``data-*``/
+    ``aria-*`` attributes pass through only where the spec allows it.
+    """
+
+    #: registered dispatcher name, used in warning messages
+    component_name: str
+    #: props (after normalization) the component understands
+    supported_props: frozenset[str] = frozenset()
+    #: props rejected with a specific reason instead of the generic unknown-prop warning
+    unsupported_prop_reasons: Mapping[str, str] = {}
+    #: whether arbitrary data-*/aria-* attributes pass through to the rendered element
+    allow_data_aria_props = False
+    #: aria-* attribute names allowed even when allow_data_aria_props is False
+    extra_allowed_aria_props: frozenset[str] = frozenset()
+    #: supported props that may hold non-scalar values
+    non_scalar_props: frozenset[str] = frozenset()
+    #: supported props where an explicit None is meaningful (kept) rather than treated as unset
+    none_meaningful_props: frozenset[str] = frozenset()
+
+    def resolve_props(self, context: Context) -> dict[str, Any]:
+        return self.filter_component_props(super().resolve_props(context))
+
+    def filter_component_props(self, props: dict[str, Any]) -> dict[str, Any]:
+        filtered: dict[str, Any] = {}
+        for key, value in props.items():
+            if value is None:
+                # Treat None the same as an unset prop, mirroring undefined in JSX. Props in
+                # none_meaningful_props mirror React props where null overrides a default.
+                if key in self.none_meaningful_props and key in self.supported_props:
+                    filtered[key] = value
+                continue
+            reason = self.unsupported_prop_reasons.get(key)
+            if reason:
+                warnings.warn(f"Prop '{key}' will be ignored: {reason}")
+                continue
+            if _EVENT_HANDLER_PROP_RE.match(key):
+                warnings.warn(f"Prop '{key}' will be ignored: {_EVENT_HANDLER_REASON}")
+                continue
+            attr_name = to_html_attr_name(key)
+            if attr_name.startswith("data-") or attr_name.startswith("aria-"):
+                if not self.allow_data_aria_props and attr_name not in self.extra_allowed_aria_props:
+                    warnings.warn(
+                        f"Prop '{key}' is not supported on '{self.component_name}' and will be ignored"
+                    )
+                    continue
+                if not _is_scalar_prop_value(value):
+                    warnings.warn(
+                        f"Prop '{key}' with non-scalar value is not supported by static table "
+                        "components and will be ignored"
+                    )
+                    continue
+                filtered[attr_name] = value
+                continue
+            if key not in self.supported_props:
+                warnings.warn(
+                    f"Prop '{key}' is not a supported '{self.component_name}' prop and will be ignored"
+                )
+                continue
+            if key == "style":
+                if not isinstance(value, (str, dict)):
+                    warnings.warn("Prop 'style' must be a string or dict; it will be ignored")
+                    continue
+            elif not _is_scalar_prop_value(value) and key not in self.non_scalar_props:
+                warnings.warn(
+                    f"Prop '{key}' with non-scalar value is not supported by static table "
+                    "components and will be ignored"
+                )
+                continue
+            filtered[key] = value
+        return filtered
+
+    def resolve_table_styles(self) -> Any:
+        return self.resolve_vanilla_extract_mapping(_TABLE_STYLE_PATH)
+
+    def warn_outside_table(self):
+        warnings.warn(
+            f"'{self.component_name}' was rendered outside of a '{{% ui \"table\" %}}' component; "
+            "rendering fallback markup"
+        )
+
+    def collect_data_aria_attrs(self, props: dict[str, Any]) -> dict[str, Any]:
+        return {
+            key: value for key, value in props.items() if key.startswith("data-") or key.startswith("aria-")
+        }
+
+
+class UITableRenderer(UITableComponentRendererBase):
+    component_name = "table"
+    supported_props = frozenset(
+        {
+            "id",
+            "className",
+            "style",
+            "header",
+            "footer",
+            "mode",
+            "sortOrder",
+            "sortMode",
+            "sortBehavior",
+            "sortQueryParam",
+            "renderEmptyState",
+            "emptyState",
+        }
+    )
+    unsupported_prop_reasons = _TABLE_UNSUPPORTED_PROPS
+    extra_allowed_aria_props = frozenset({"aria-label", "aria-labelledby", "aria-describedby"})
+    non_scalar_props = frozenset({"sortOrder", "header", "footer", "renderEmptyState", "emptyState"})
+    none_meaningful_props = frozenset({"renderEmptyState", "emptyState"})
+
+    def resolve_component_resources(self) -> list[FrontendResource]:
+        # Icon.css is included unconditionally (sortable columns may render sort icons) to keep
+        # resource discovery deterministic.
+        return [
+            self.resolve_frontend_resource(_TABLE_STYLE_PATH),
+            self.resolve_frontend_resource(ICON_STYLE_PATH),
+        ]
+
+    def render_children_for_component(self, context: Context, props: dict[str, Any]) -> str:
+        with _push_table_state(context, self.build_table_state(context, props)):
+            return self.render_children(context)
+
+    def build_table_state(self, context: Context, props: dict[str, Any]) -> TableRenderState:
+        sort_mode = self.validate_enum_prop(
+            props,
+            prop_name="sortMode",
+            valid_values=VALID_SORT_MODES,
+            default_value="single",
+        )
+        sort_behavior = self.validate_enum_prop(
+            props,
+            prop_name="sortBehavior",
+            valid_values=VALID_SORT_BEHAVIORS,
+            default_value="toggle",
+        )
+        sort_query_param = str(props.get("sortQueryParam") or DEFAULT_SORT_QUERY_PARAM)
+        return TableRenderState(
+            sort_order=self.resolve_sort_order(props),
+            sort_mode=sort_mode,  # type: ignore[arg-type] # validated above
+            sort_behavior=sort_behavior,  # type: ignore[arg-type] # validated above
+            sort_query_param=sort_query_param,
+            empty_state_html=self.resolve_empty_state_html(context, props),
+        )
+
+    def resolve_sort_order(self, props: dict[str, Any]) -> list[TableSortDescriptor]:
+        raw_sort_order = props.get("sortOrder")
+        if raw_sort_order is None:
+            return []
+        if not isinstance(raw_sort_order, (list, tuple)):
+            warnings.warn(
+                "Prop 'sortOrder' must be a list of sort descriptors "
+                '({"column": ..., "direction": ...}); it will be ignored'
+            )
+            return []
+        descriptors: list[TableSortDescriptor] = []
+        for entry in raw_sort_order:
+            column = entry.get("column") if isinstance(entry, dict) else None
+            direction = entry.get("direction") if isinstance(entry, dict) else None
+            if not column or direction not in VALID_SORT_DIRECTIONS:
+                warnings.warn(f"Ignoring invalid 'sortOrder' descriptor: {entry!r}")
+                continue
+            descriptors.append(TableSortDescriptor(column=str(column), direction=direction))
+        return descriptors
+
+    def resolve_empty_state_html(self, context: Context, props: dict[str, Any]) -> str | None:
+        # renderEmptyState matches the React prop name; emptyState is accepted as a friendlier
+        # alias. Explicit None or False disables the empty state (mirroring
+        # renderEmptyState={null} in React); True or an absent prop uses the React default.
+        if "renderEmptyState" in props:
+            value = props["renderEmptyState"]
+        elif "emptyState" in props:
+            value = props["emptyState"]
+        else:
+            value = True
+        if value is None or value is False:
+            return None
+        if value is True:
+            return "<em>No results</em>"
+        return render_content(value, context, prop_name="renderEmptyState", origin=self.origin)
+
+    def render_component(self, context: Context, props: dict[str, Any], children_html: str) -> str:
+        mode = self.validate_enum_prop(
+            props,
+            prop_name="mode",
+            valid_values=VALID_TABLE_MODES,
+            default_value="default",
+        )
+        table_styles = self.resolve_table_styles()
+
+        header_html = render_content(props.get("header"), context, prop_name="header", origin=self.origin)
+        footer_html = render_content(props.get("footer"), context, prop_name="footer", origin=self.origin)
+        has_header = bool(header_html)
+        has_footer = bool(footer_html)
+
+        wrapper_attrs: dict[str, Any] = {
+            "data-apui": "table",
+            "data-mode": mode,
+            "data-has-header": "true" if has_header else None,
+            "data-has-footer": "true" if has_footer else None,
+            "className": self.join_classes(
+                self.get_style_class(table_styles, "wrapper"),
+                props.get("className"),
+                self.get_style_class(table_styles, "hasHeader")
+                if has_header
+                else self.get_style_class(table_styles, "hasNoHeader"),
+                None if has_footer else self.get_style_class(table_styles, "hasNoFooter"),
+            ),
+            "style": props.get("style"),
+        }
+
+        table_attrs: dict[str, Any] = {
+            "id": props.get("id"),
+            "aria-label": props.get("aria-label"),
+            "aria-labelledby": props.get("aria-labelledby"),
+            "aria-describedby": props.get("aria-describedby"),
+        }
+        table_html = self._render_tag("table", table_attrs, children_html)
+        scroll_container_class = self.get_style_class(table_styles, "scrollContainer")
+        scroll_html = f'<div class="{conditional_escape(scroll_container_class)}">{table_html}</div>'
+
+        return self._render_tag("div", wrapper_attrs, f"{header_html}{scroll_html}{footer_html}")
+
+
+class UITableHeaderRenderer(UITableComponentRendererBase):
+    component_name = "table_header"
+    # The React TableHeader accepts no styling props; nested/grouped columns are a non-goal.
+    supported_props = frozenset()
+    unsupported_prop_reasons = {"columns": _COLLECTION_REASON}
+
+    def render_component(self, context: Context, props: dict[str, Any], children_html: str) -> str:
+        if get_current_table_state(context) is None:
+            self.warn_outside_table()
+        table_styles = self.resolve_table_styles()
+        header_row_class = self.get_style_class(table_styles, "headerRow")
+        row_html = f'<tr class="{conditional_escape(header_row_class)}">{children_html}</tr>'
+        return mark_safe(f"<thead>{row_html}</thead>")
+
+
+class UITableColumnRenderer(UITableComponentRendererBase):
+    component_name = "table_column"
+    supported_props = frozenset(
+        {
+            "id",
+            "className",
+            "style",
+            "key",
+            "align",
+            "width",
+            "colSpan",
+            "isRowHeader",
+            "hideHeader",
+            "allowsSorting",
+            "sortHref",
+            "sortDirection",
+            "sortPosition",
+            "showSortPosition",
+        }
+    )
+    unsupported_prop_reasons = {"childColumns": _NESTED_COLUMNS_REASON}
+
+    def render_component(self, context: Context, props: dict[str, Any], children_html: str) -> str:
+        state = get_current_table_state(context)
+        if state is None:
+            self.warn_outside_table()
+
+        align = self.validate_optional_enum_prop(props, prop_name="align", valid_values=VALID_ALIGNMENTS)
+        explicit_direction = self.validate_optional_enum_prop(
+            props, prop_name="sortDirection", valid_values=VALID_SORT_DIRECTIONS
+        )
+        key = props.get("key")
+        key = str(key) if key is not None else None
+        allows_sorting = bool(props.get("allowsSorting"))
+        is_row_header = bool(props.get("isRowHeader"))
+        col_span = _coerce_int(props.get("colSpan"))
+        spans_multiple = col_span is not None and col_span > 1
+
+        descriptor: TableSortDescriptor | None = None
+        if state is not None and key is not None:
+            descriptor = next((entry for entry in state.sort_order if entry.column == key), None)
+
+        sort_direction = explicit_direction or (descriptor.direction if descriptor else None)
+        sort_position = _coerce_int(props.get("sortPosition"))
+        if sort_position is None and descriptor is not None and state is not None:
+            sort_position = state.sort_order.index(descriptor) + 1
+        if "showSortPosition" in props:
+            show_sort_position = bool(props["showSortPosition"])
+        else:
+            show_sort_position = (
+                state is not None and state.sort_mode == "multiple" and len(state.sort_order) > 1
+            )
+
+        column_state = TableColumnState(
+            key=key,
+            align=align,  # type: ignore[arg-type] # validated above
+            is_row_header=is_row_header,
+            allows_sorting=allows_sorting,
+            sort_direction=sort_direction,  # type: ignore[arg-type] # validated above
+            sort_position=sort_position,
+            show_sort_position=show_sort_position,
+        )
+        if state is not None:
+            state.columns.append(column_state)
+            if is_row_header:
+                state.has_explicit_row_header = True
+
+        table_styles = self.resolve_table_styles()
+
+        href: str | None = None
+        if allows_sorting:
+            sort_href = props.get("sortHref")
+            if sort_href is not None:
+                href = str(sort_href)
+            elif state is not None and key is not None:
+                href = self.build_sort_url(context, state, key)
+            if href is None:
+                warnings.warn(
+                    f"Could not build a sort URL for column '{key or '<no key>'}': pass 'sortHref', or "
+                    "pass 'key' and ensure 'request' is available in the template context. The header "
+                    "will render without a link."
+                )
+
+        content_html = self.render_header_content(props, children_html, table_styles, href)
+        sort_wrapper_html = ""
+        if allows_sorting:
+            sort_wrapper_html = self.render_sort_wrapper(column_state, table_styles)
+        header_cell_wrapper_class = self.get_style_class(table_styles, "headerCellWrapper")
+        cell_children = (
+            f'<div class="{conditional_escape(header_cell_wrapper_class)}">'
+            f"{content_html}{sort_wrapper_html}</div>"
+        )
+
+        # aria-sort: 'ascending'/'descending' when sorted, 'none' when sortable but unsorted,
+        # otherwise unset. See the comment in Table.tsx around aria-sort for background.
+        aria_sort = None
+        if allows_sorting:
+            aria_sort = sort_direction or "none"
+
+        attrs: dict[str, Any] = {
+            # The React implementation merges the user className before the default classes for
+            # header cells (via mergeProps); match that ordering for parity.
+            "className": self.join_classes(
+                props.get("className"),
+                self.get_style_class(table_styles, "headerCell"),
+                self.get_style_class(table_styles, "alignEnd") if align == "end" else None,
+                self.get_style_class(table_styles, "spansMultiple") if spans_multiple else None,
+            ),
+            "id": props.get("id"),
+            "style": self.resolve_column_style(props, table_styles),
+            "data-align": align,
+            "data-sort-direction": sort_direction,
+            "data-spans-multiple": "true" if spans_multiple else None,
+            "colspan": col_span,
+            "scope": "col",
+            "aria-sort": aria_sort,
+        }
+        return self._render_tag("th", attrs, cell_children)
+
+    def render_header_content(
+        self,
+        props: dict[str, Any],
+        children_html: str,
+        table_styles: Any,
+        href: str | None,
+    ) -> str:
+        content_class = conditional_escape(self.get_style_class(table_styles, "headerCellContent"))
+        if href is not None:
+            content = f'<a class="{content_class}" href="{conditional_escape(href)}">{children_html}</a>'
+        else:
+            content = f'<div class="{content_class}">{children_html}</div>'
+        if props.get("hideHeader"):
+            # React wraps the content in react-aria's VisuallyHidden (plus a focus tooltip the
+            # static renderer cannot provide). The text must stay available to screen readers.
+            content = f'<div style="{_VISUALLY_HIDDEN_STYLE}">{content}</div>'
+        return content
+
+    def render_sort_wrapper(self, column_state: TableColumnState, table_styles: Any) -> str:
+        if column_state.sort_direction == "descending":
+            icon_html = self.render_icon(
+                _ARROW_DOWN_SVG_PATH, "xs", [self.get_style_class(table_styles, "sortIcon")]
+            )
+        elif column_state.sort_direction == "ascending":
+            icon_html = self.render_icon(
+                _ARROW_UP_SVG_PATH, "xs", [self.get_style_class(table_styles, "sortIcon")]
+            )
+        else:
+            icon_html = self.render_icon(
+                _ARROW_UP_SVG_PATH, "xs", [self.get_style_class(table_styles, "sortIconUnsorted")]
+            )
+        position_html = ""
+        if column_state.show_sort_position:
+            position = column_state.sort_position
+            position_html = f"<span>{position if position is not None else ''}</span>"
+        sort_wrapper_class = self.get_style_class(table_styles, "sortWrapper")
+        return f'<span class="{conditional_escape(sort_wrapper_class)}">{icon_html}{position_html}</span>'
+
+    def resolve_column_style(self, props: dict[str, Any], table_styles: Any) -> Any:
+        style = props.get("style")
+        width = props.get("width")
+        if width is None:
+            return style
+        width_var = self.resolve_column_width_var(table_styles)
+        if width_var is None:
+            warnings.warn(
+                "Could not resolve the table columnWidth CSS variable; the 'width' prop will be ignored"
+            )
+            return style
+        width_style = {width_var: _pixelify(width)}
+        if isinstance(style, dict):
+            return {**style, **width_style}
+        if isinstance(style, str) and style.strip():
+            return f"{style.rstrip().rstrip(';')}; {style_dict_to_string(width_style)}"
+        return width_style
+
+    def resolve_column_width_var(self, table_styles: Any) -> str | None:
+        """Resolve the CSS custom property name for the table columnWidth theme var.
+
+        The vanilla-extract mapping serializes theme vars as ``var(--name)`` references (the same
+        values ``assignInlineVars`` accepts in the React implementation).
+        """
+        var_reference = self.get_nested_style_class(table_styles, "vars", "columnWidth")
+        if not var_reference:
+            return None
+        match = re.fullmatch(r"var\((--[^,)]+)(?:,.*)?\)", var_reference.strip())
+        if match:
+            return match.group(1)
+        if var_reference.startswith("--"):
+            return var_reference
+        return None
+
+    def build_sort_url(self, context: Context, state: TableRenderState, key: str) -> str | None:
+        request = context.get("request")
+        if request is None or not hasattr(request, "GET") or not hasattr(request, "path"):
+            return None
+        params = request.GET.copy()
+        next_order = self.get_next_sort_order(state, key)
+        if next_order:
+            params[state.sort_query_param] = ",".join(
+                f"{'-' if entry.direction == 'descending' else ''}{entry.column}" for entry in next_order
+            )
+        else:
+            params.pop(state.sort_query_param, None)
+        query_string = params.urlencode()
+        return f"{request.path}?{query_string}" if query_string else request.path
+
+    def get_next_sort_order(self, state: TableRenderState, key: str) -> list[TableSortDescriptor]:
+        """The sort order the column's link should apply, mirroring ``useTableSorter.getSortOrder``.
+
+        The direction cycle is unsorted -> ascending -> descending -> off. ``replace`` mode matches
+        the React behaviour without the meta/ctrl force-toggle (which requires JavaScript).
+        """
+        current = next((entry for entry in state.sort_order if entry.column == key), None)
+        current_direction = current.direction if current else None
+        if state.sort_mode == "single" or state.sort_behavior == "replace":
+            if current_direction == "descending":
+                return []
+            direction: Literal["ascending", "descending"] = (
+                "descending" if current_direction == "ascending" else "ascending"
+            )
+            return [TableSortDescriptor(column=key, direction=direction)]
+        if current_direction == "descending":
+            return [entry for entry in state.sort_order if entry.column != key]
+        if current_direction == "ascending":
+            return [
+                TableSortDescriptor(column=key, direction="descending") if entry.column == key else entry
+                for entry in state.sort_order
+            ]
+        return [*state.sort_order, TableSortDescriptor(column=key, direction="ascending")]
+
+
+class UITableBodyRenderer(UITableComponentRendererBase):
+    component_name = "table_body"
+    supported_props = frozenset({"id", "className", "style"})
+    unsupported_prop_reasons = {"items": _COLLECTION_REASON}
+    allow_data_aria_props = True
+
+    def render_children_for_component(self, context: Context, props: dict[str, Any]) -> str:
+        # The row-count snapshot lives on the render state (in context.render_context), not on
+        # self: this renderer is a template node, and per-render state on the instance would leak
+        # between concurrent renders of a shared compiled template.
+        state = get_current_table_state(context)
+        if state is None:
+            self.warn_outside_table()
+        else:
+            state.body_start_row_counts.append(state.row_count)
+        return self.render_children(context)
+
+    def render_component(self, context: Context, props: dict[str, Any], children_html: str) -> str:
+        state = get_current_table_state(context)
+        if state is not None and state.body_start_row_counts:
+            rows_before = state.body_start_row_counts.pop()
+            if state.row_count == rows_before and state.empty_state_html is not None:
+                children_html += self.render_empty_state(state)
+        attrs: dict[str, Any] = {
+            "className": props.get("className"),
+            "id": props.get("id"),
+            "style": props.get("style"),
+            **self.collect_data_aria_attrs(props),
+        }
+        return self._render_tag("tbody", attrs, children_html)
+
+    def render_empty_state(self, state: TableRenderState) -> str:
+        table_styles = self.resolve_table_styles()
+        no_results_class = self.get_style_class(table_styles, "noResults")
+        column_count = len(state.columns) or 1
+        return (
+            f'<tr><td colspan="{column_count}">'
+            f'<div class="{conditional_escape(no_results_class)}">{state.empty_state_html}</div>'
+            "</td></tr>"
+        )
+
+
+class UITableRowRenderer(UITableComponentRendererBase):
+    component_name = "table_row"
+    supported_props = frozenset({"id", "key", "className", "style"})
+    unsupported_prop_reasons = {"isSelected": _SELECTION_REASON, "isDisabled": _SELECTION_REASON}
+    allow_data_aria_props = True
+
+    def render_children_for_component(self, context: Context, props: dict[str, Any]) -> str:
+        state = get_current_table_state(context)
+        if state is None:
+            self.warn_outside_table()
+            return self.render_children(context)
+        previous_cell_index = state.current_row_cell_index
+        state.current_row_cell_index = 0
+        try:
+            return self.render_children(context)
+        finally:
+            state.current_row_cell_index = previous_cell_index
+            state.row_count += 1
+
+    def render_component(self, context: Context, props: dict[str, Any], children_html: str) -> str:
+        table_styles = self.resolve_table_styles()
+        key = props.get("key")
+        attrs: dict[str, Any] = {
+            # The React implementation merges the user className before styles.row (via
+            # mergeProps); match that ordering for parity.
+            "className": self.join_classes(
+                props.get("className"),
+                self.get_style_class(table_styles, "row"),
+            ),
+            "id": props.get("id"),
+            "style": props.get("style"),
+            "data-key": str(key) if key is not None else None,
+            **self.collect_data_aria_attrs(props),
+        }
+        return self._render_tag("tr", attrs, children_html)
+
+
+class UITableCellRenderer(UITableComponentRendererBase):
+    component_name = "table_cell"
+    supported_props = frozenset({"id", "className", "style", "colSpan", "rowSpan"})
+    allow_data_aria_props = True
+
+    def render_component(self, context: Context, props: dict[str, Any], children_html: str) -> str:
+        state = get_current_table_state(context)
+        col_span = _coerce_int(props.get("colSpan"))
+        row_span = _coerce_int(props.get("rowSpan"))
+
+        column: TableColumnState | None = None
+        cell_index: int | None = None
+        if state is None or state.current_row_cell_index is None:
+            warnings.warn(
+                "'table_cell' was rendered outside of a '{% ui \"table_row\" %}' component; "
+                "column metadata (alignment, row header) will not be applied"
+            )
+        else:
+            cell_index = state.current_row_cell_index
+            state.current_row_cell_index = cell_index + max(col_span or 1, 1)
+            if cell_index < len(state.columns):
+                column = state.columns[cell_index]
+            elif not state.warned_extra_cells:
+                state.warned_extra_cells = True
+                warnings.warn(
+                    "A 'table_row' rendered more 'table_cell' components than there are registered "
+                    "'table_column' components; extra cells render without column metadata. "
+                    "(warning shown once per table)"
+                )
+
+        align = column.align if column else None
+        is_row_header = False
+        if column is not None and state is not None and cell_index is not None:
+            is_row_header = column.is_row_header if state.has_explicit_row_header else cell_index == 0
+
+        table_styles = self.resolve_table_styles()
+        attrs: dict[str, Any] = {
+            "className": self.join_classes(
+                self.get_style_class(table_styles, "cell"),
+                props.get("className"),
+                self.get_style_class(table_styles, "alignEnd") if align == "end" else None,
+                self.get_style_class(table_styles, "alignCenter") if align == "center" else None,
+            ),
+            "id": props.get("id"),
+            "style": props.get("style"),
+            "data-align": align,
+            "colspan": col_span,
+            "rowspan": row_span,
+            # Rendered as <td role="rowheader"> rather than <th scope="row"> so browser default
+            # <th> styling (bold, centered) cannot diverge from the React table's appearance.
+            "role": "rowheader" if is_row_header else None,
+            **self.collect_data_aria_attrs(props),
+        }
+        return self._render_tag("td", attrs, children_html)

--- a/packages/ap-ui/alliance_platform/ui/templatetags/alliance_platform/html_components/registry.py
+++ b/packages/ap-ui/alliance_platform/ui/templatetags/alliance_platform/html_components/registry.py
@@ -50,9 +50,21 @@ from .components.button_group import UIButtonGroupRenderer  # noqa: E402
 from .components.input import UINumberInputRenderer  # noqa: E402
 from .components.input import UITextAreaRenderer  # noqa: E402
 from .components.input import UITextInputRenderer  # noqa: E402
+from .components.table import UITableBodyRenderer  # noqa: E402
+from .components.table import UITableCellRenderer  # noqa: E402
+from .components.table import UITableColumnRenderer  # noqa: E402
+from .components.table import UITableHeaderRenderer  # noqa: E402
+from .components.table import UITableRenderer  # noqa: E402
+from .components.table import UITableRowRenderer  # noqa: E402
 
 built_in_registry.register_renderer("button", UIButtonRenderer)
 built_in_registry.register_renderer("button_group", UIButtonGroupRenderer)
 built_in_registry.register_renderer("text_input", UITextInputRenderer)
 built_in_registry.register_renderer("number_input", UINumberInputRenderer)
 built_in_registry.register_renderer("text_area", UITextAreaRenderer)
+built_in_registry.register_renderer("table", UITableRenderer)
+built_in_registry.register_renderer("table_header", UITableHeaderRenderer)
+built_in_registry.register_renderer("table_body", UITableBodyRenderer)
+built_in_registry.register_renderer("table_column", UITableColumnRenderer)
+built_in_registry.register_renderer("table_row", UITableRowRenderer)
+built_in_registry.register_renderer("table_cell", UITableCellRenderer)

--- a/packages/ap-ui/docs/templatetags.rst
+++ b/packages/ap-ui/docs/templatetags.rst
@@ -51,6 +51,71 @@ The dispatcher also supports ``as <var>``:
     {% ui "button" as save_button_html %}Save{% endui %}
     {{ save_button_html }}
 
+Static HTML table components
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``{% ui "table" %}`` and its child components render the Alliance UI table as static HTML — the
+same visual classes and state data attributes as the React ``Table``, but with no JavaScript
+runtime. Use it for read-only list views (the common CRUD case) where sorting happens on the
+backend through normal links. Row selection, client-side sorting and the interactive keyboard
+grid behaviour are **not** supported — use the React-backed :ttag:`Table` tag when you need
+those.
+
+The available components are ``table``, ``table_header``, ``table_body``, ``table_column``,
+``table_row`` and ``table_cell``. A CRUD list view with backend sorting looks like:
+
+.. code-block:: html+django
+
+    {% load alliance_platform.ui %}
+
+    {% ui "table" aria_label="User list" sort_order=request|table_sort_order:"order" sort_query_param="order" sort_mode="multiple" sort_behavior="toggle" %}
+      {% ui "table_header" %}
+        {% ui "table_column" key="name" allows_sorting=True %}Name{% endui %}
+        {% ui "table_column" key="email" allows_sorting=True %}Email{% endui %}
+        {% ui "table_column" key="active" align="center" %}Active{% endui %}
+        {% ui "table_column" hide_header=True width=96 %}Actions{% endui %}
+      {% endui %}
+      {% ui "table_body" %}
+        {% for obj in object_list %}
+          {% ui "table_row" key=obj.pk %}
+            {% ui "table_cell" %}{{ obj.name }}{% endui %}
+            {% ui "table_cell" %}{{ obj.email }}{% endui %}
+            {% ui "table_cell" %}{{ obj.is_active }}{% endui %}
+            {% ui "table_cell" %}{# action buttons #}{% endui %}
+          {% endui %}
+        {% endfor %}
+      {% endui %}
+    {% endui %}
+
+Sortable columns (``allows_sorting=True`` with a ``key``) render their header content as a link
+that updates the table's sort query parameter (``sort_query_param``, default ``"ordering"``),
+preserving all other query parameters. :tfilter:`table_sort_order` extracts the current order
+from the request in the format ``sort_order`` expects. Each click cycles the column through
+ascending → descending → unsorted. With ``sort_mode="single"`` (the default) sorting by a column
+replaces any other sorting; with ``sort_mode="multiple"`` and ``sort_behavior="toggle"`` other
+columns are preserved, while ``sort_behavior="replace"`` replaces them (the React ctrl/cmd-click
+multi-sort has no static equivalent). ``request`` must be available in the template context for
+link generation; alternatively pass an explicit URL when it is computed elsewhere:
+
+.. code-block:: html+django
+
+    {% ui "table_column" allows_sorting=True sort_href="?order=-created_at" sort_direction="descending" %}
+      Created
+    {% endui %}
+
+Other notable behaviour:
+
+* The first column is treated as the row header for accessibility; set ``is_row_header=True`` on
+  one or more columns to override this.
+* ``table_cell`` inherits alignment and row-header status from the ``table_column`` at the same
+  position, so alignment is set once on the column.
+* An empty ``table_body`` renders a "No results" empty state spanning all columns. Customise it
+  with ``empty_state="..."`` or disable it with ``empty_state=False``.
+* ``header``/``footer`` content (e.g. a heading or pagination) can be passed to ``table`` and is
+  rendered above/below the scrollable table area.
+* Unsupported interactive props (selection, ``on*`` callbacks, ``items``/``columns`` collections)
+  warn and are ignored rather than rendering broken interactivity.
+
 .. templatetag:: Button
 
 ``Button``
@@ -245,6 +310,13 @@ submenu with an icon for the current user's account management link and a logout
 Render an `Table <https://main--64894ae38875dcf46367336f.chromatic.com/?path=/docs/ui-table--docs>`_ component.
 
 You can use ``TableHeader``, ``TableBody``, ``Row``, ``Column`` and ``Cell`` components to build the menu.
+
+.. note::
+
+    For read-only list views that only need backend sort links there is also a static HTML
+    implementation with no JavaScript runtime — see `Static HTML table components`_ under the
+    :ttag:`ui` tag. Use this React-backed tag when you need row selection or the interactive
+    keyboard grid behaviour.
 
 This example renders a list of records, and allows sorting of columns by clicking on the column headers. This makes
 use of the :tfilter:`table_sort_order` filter to determine the current sort order of the column and pass it through

--- a/packages/ap-ui/scripts/generateHtmlUiParityFixtures.mjs
+++ b/packages/ap-ui/scripts/generateHtmlUiParityFixtures.mjs
@@ -15,10 +15,12 @@ const CASE_MODULES = [
     './parity_cases/text_input.mjs',
     './parity_cases/number_input.mjs',
     './parity_cases/text_area.mjs',
+    './parity_cases/table.mjs',
 ];
 
 const BUTTON_COMPONENTS = new Set(['button', 'button_group']);
 const INPUT_COMPONENTS = new Set(['text_input', 'number_input', 'text_area']);
+const TABLE_COMPONENTS = new Set(['table']);
 
 const require = createRequire(import.meta.url);
 const GENERATED_AT_ENV_VAR = 'AP_UI_PARITY_GENERATED_AT_UTC';
@@ -124,6 +126,16 @@ async function importDefault(modulePath) {
     return module.default ?? module;
 }
 
+async function importBareModule(specifier) {
+    try {
+        // Prefer bare imports so vite-node resolves the same singletons as the component module graph.
+        return await import(specifier);
+    } catch {
+        const uiRequire = await getUiRequire();
+        return import(pathToFileURL(uiRequire.resolve(specifier)).href);
+    }
+}
+
 async function loadParityComponents(component) {
     if (parityComponentRuntimeCache.has(component)) {
         return parityComponentRuntimeCache.get(component);
@@ -153,6 +165,21 @@ async function loadParityComponents(component) {
             NumberInput: await importDefault(
                 path.join(uiPackageDir, 'components/number-input/NumberInput.tsx')
             ),
+        };
+    } else if (component === 'table') {
+        // Table itself comes from the ui package; the collection components (TableHeader etc.)
+        // are the react-stately ones the ui package re-exports.
+        const reactStately = await importBareModule('react-stately');
+        components = {
+            Table: await importDefault(path.join(uiPackageDir, 'components/table/Table.tsx')),
+            ColumnHeaderLink: await importDefault(
+                path.join(uiPackageDir, 'components/table/ColumnHeaderLink.tsx')
+            ),
+            TableHeader: reactStately.TableHeader,
+            TableBody: reactStately.TableBody,
+            Column: reactStately.Column,
+            Row: reactStately.Row,
+            Cell: reactStately.Cell,
         };
     } else {
         throw new Error(`Unsupported parity component runtime: ${component}`);
@@ -391,16 +418,58 @@ function normalizeReactAriaIds(html, component) {
     return normalized;
 }
 
+// React emits style declarations without spacing (`height:120px`); the Python renderer emits
+// `height: 120px`. Normalize to the Python format.
+function normalizeInlineStyleSpacing(html) {
+    return html.replace(/\sstyle="([^"]*)"/g, (_match, value) => {
+        const styleValue = value.replace(/:\s*/g, ': ').replace(/;\s*/g, '; ').trim();
+        return ` style="${styleValue}"`;
+    });
+}
+
 function normalizeInputComponentHtml(html, component) {
     let normalized = html;
     normalized = normalized.replace(CAMEL_CASE_ATTR_RE, (_match, name) => ` ${name.toLowerCase()}=`);
     normalized = normalizeReactAriaIds(normalized, component);
-    // React emits style declarations without spacing (`height:120px`); the Python renderer emits
-    // `height: 120px`. Normalize to the Python format.
-    normalized = normalized.replace(/\sstyle="([^"]*)"/g, (_match, value) => {
-        const styleValue = value.replace(/:\s*/g, ': ').replace(/;\s*/g, '; ').trim();
-        return ` style="${styleValue}"`;
-    });
+    normalized = normalizeInlineStyleSpacing(normalized);
+    return normalized;
+}
+
+/**
+ * Normalize the intentional differences between the React Aria table and the static renderer.
+ *
+ * The React Table is an interactive ARIA grid; the static table keeps native table semantics
+ * instead (see the table components spec). Concretely:
+ *
+ * - Grid roles (`grid`/`row`/`rowgroup`/`columnheader`/`gridcell`), tab indexes and
+ *   `aria-colindex`-style attributes are dropped; `role="rowheader"` is kept as the static
+ *   renderer emits it too.
+ * - `scope="col"` is added to header cells (native semantics; ARIA grids don't use scope).
+ * - Sort link hrefs are absolute (built from the SSR currentUrl); the static renderer emits
+ *   path-relative URLs.
+ * - Generated hashes in CSS custom property names within style attributes are stripped, the same
+ *   way class name hashes are.
+ */
+function normalizeTableComponentHtml(html, component) {
+    let normalized = html;
+    normalized = normalized.replace(/\srole="(grid|rowgroup|row|columnheader|gridcell)"/g, '');
+    normalized = normalized.replace(/\stabindex="-?\d+"/g, '');
+    normalized = normalized.replace(
+        /\saria-(colindex|rowindex|colcount|rowcount|colspan|rowspan|multiselectable|selected)="[^"]*"/g,
+        ''
+    );
+    // react-aria stamps collection bookkeeping attributes on every element; the static renderer
+    // renders data-key only where the caller passes a key (covered by unit tests, not fixtures).
+    normalized = normalized.replace(/\sdata-collection="[^"]*"/g, '');
+    normalized = normalized.replace(/\sdata-key="[^"]*"/g, '');
+    // The empty state row uses a raw JSX <td colSpan={...}> which the server renderer emits
+    // verbatim; attribute names are case-insensitive in HTML.
+    normalized = normalized.replace(/\s(colSpan|rowSpan)=/g, (_match, name) => ` ${name.toLowerCase()}=`);
+    normalized = normalizeReactAriaIds(normalized, component);
+    normalized = normalized.replace(/<th(?![\w-])/g, '<th scope="col"');
+    normalized = normalized.replace(/href="http:\/\/testserver/g, 'href="');
+    normalized = normalized.replace(/(--[\w-]+)__[a-z0-9]+\s*:/g, '$1:');
+    normalized = normalizeInlineStyleSpacing(normalized);
     return normalized;
 }
 
@@ -420,6 +489,9 @@ function normalizeDomAttributes(html, component, testCase, allowedPrefixes, keep
     }
     if (INPUT_COMPONENTS.has(component)) {
         normalized = normalizeInputComponentHtml(normalized, component);
+    }
+    if (TABLE_COMPONENTS.has(component)) {
+        normalized = normalizeTableComponentHtml(normalized, component);
     }
     normalized = normalized.replace(/\sclass="([^"]*)"/g, (_match, classValue) => {
         const classTokens = normalizeClassTokens(classValue, allowedPrefixes, keepClassTokens);
@@ -471,6 +543,15 @@ async function generateFixtureFromModule(modulePath, runtime) {
 
     const serializedCases = [];
     for (const testCase of cases) {
+        // Cases may specify the current URL (path + query) the render happens at; ColumnHeaderLink
+        // reads it from globalSsrContext during SSR. The matching Python parity test builds a
+        // request for the same URL. The origin is stripped again during normalization.
+        const currentUrl = testCase.meta?.current_url;
+        if (currentUrl) {
+            globalThis.globalSsrContext = {
+                currentUrl: new URL(currentUrl, 'http://testserver').toString(),
+            };
+        }
         const { html, warnings } = captureWarnings(() =>
             runtime.renderToStaticMarkup(
                 testCase.buildElement({
@@ -479,6 +560,9 @@ async function generateFixtureFromModule(modulePath, runtime) {
                 })
             )
         );
+        if (currentUrl) {
+            delete globalThis.globalSsrContext;
+        }
         const normalizedHtml = normalizeRenderedHtml(
             component,
             testCase,

--- a/packages/ap-ui/scripts/parity_cases/table.mjs
+++ b/packages/ap-ui/scripts/parity_cases/table.mjs
@@ -1,0 +1,364 @@
+export const component = 'table';
+export const class_prefixes = ['Table', 'Icon'];
+
+// Shared helpers to keep the case definitions readable. The React Table renders sortable header
+// links through ColumnHeaderLink (the same component the React-backed Django tags use); the
+// static renderer always renders sortable headers as links when a URL can be resolved.
+function buildTable({ React, components }, tableProps, columns, rows) {
+    const { Table, TableHeader, TableBody, Column, Row, Cell } = components;
+    return React.createElement(
+        Table,
+        tableProps,
+        React.createElement(
+            TableHeader,
+            null,
+            columns.map(([key, props, label]) =>
+                React.createElement(Column, { key, ...props }, label)
+            )
+        ),
+        React.createElement(
+            TableBody,
+            null,
+            rows.map((cells, rowIndex) =>
+                React.createElement(
+                    Row,
+                    { key: `row-${rowIndex}` },
+                    cells.map((cell, cellIndex) => {
+                        const [props, content] = Array.isArray(cell) ? cell : [null, cell];
+                        return React.createElement(Cell, { key: `cell-${cellIndex}`, ...props }, content);
+                    })
+                )
+            )
+        )
+    );
+}
+
+function sortableTableProps({ React, components }, extraProps = {}) {
+    const { ColumnHeaderLink } = components;
+    return {
+        'aria-label': 'User list',
+        columnHeaderElementType: React.createElement(ColumnHeaderLink, { sortQueryParam: 'ordering' }),
+        ...extraProps,
+    };
+}
+
+export const cases = [
+    {
+        name: 'basic',
+        template:
+            '{% ui "table" aria_label="User list" %}' +
+            '{% ui "table_header" %}' +
+            '{% ui "table_column" key="name" %}Name{% endui %}' +
+            '{% ui "table_column" key="email" %}Email{% endui %}' +
+            '{% endui %}' +
+            '{% ui "table_body" %}' +
+            '{% ui "table_row" %}{% ui "table_cell" %}Jane{% endui %}{% ui "table_cell" %}jane@example.com{% endui %}{% endui %}' +
+            '{% ui "table_row" %}{% ui "table_cell" %}John{% endui %}{% ui "table_cell" %}john@example.com{% endui %}{% endui %}' +
+            '{% endui %}' +
+            '{% endui %}',
+        buildElement(runtime) {
+            return buildTable(
+                runtime,
+                { 'aria-label': 'User list' },
+                [
+                    ['name', null, 'Name'],
+                    ['email', null, 'Email'],
+                ],
+                [
+                    ['Jane', 'jane@example.com'],
+                    ['John', 'john@example.com'],
+                ]
+            );
+        },
+        meta: {},
+    },
+    {
+        name: 'class_style_merging',
+        template:
+            '{% ui "table" aria_label="User list" class="custom-table" style="max-width: 400px" %}' +
+            '{% ui "table_header" %}' +
+            '{% ui "table_column" key="name" class="custom-column" %}Name{% endui %}' +
+            '{% endui %}' +
+            '{% ui "table_body" class="custom-body" %}' +
+            '{% ui "table_row" class="custom-row" %}' +
+            '{% ui "table_cell" class="custom-cell" style="font-style: italic" %}Jane{% endui %}' +
+            '{% endui %}' +
+            '{% endui %}' +
+            '{% endui %}',
+        buildElement(runtime) {
+            const { React, components } = runtime;
+            const { Table, TableHeader, TableBody, Column, Row, Cell } = components;
+            return React.createElement(
+                Table,
+                { 'aria-label': 'User list', className: 'custom-table', style: { maxWidth: '400px' } },
+                React.createElement(
+                    TableHeader,
+                    null,
+                    React.createElement(Column, { key: 'name', className: 'custom-column' }, 'Name')
+                ),
+                React.createElement(
+                    TableBody,
+                    { className: 'custom-body' },
+                    React.createElement(
+                        Row,
+                        { key: 'row-0', className: 'custom-row' },
+                        React.createElement(
+                            Cell,
+                            { className: 'custom-cell', style: { fontStyle: 'italic' } },
+                            'Jane'
+                        )
+                    )
+                )
+            );
+        },
+        meta: {},
+    },
+    {
+        name: 'column_alignment',
+        template:
+            '{% ui "table" aria_label="User list" %}' +
+            '{% ui "table_header" %}' +
+            '{% ui "table_column" key="name" %}Name{% endui %}' +
+            '{% ui "table_column" key="active" align="center" %}Active{% endui %}' +
+            '{% ui "table_column" key="total" align="end" %}Total{% endui %}' +
+            '{% ui "table_column" key="notes" align="start" %}Notes{% endui %}' +
+            '{% endui %}' +
+            '{% ui "table_body" %}' +
+            '{% ui "table_row" %}' +
+            '{% ui "table_cell" %}Jane{% endui %}' +
+            '{% ui "table_cell" %}Yes{% endui %}' +
+            '{% ui "table_cell" %}10{% endui %}' +
+            '{% ui "table_cell" %}-{% endui %}' +
+            '{% endui %}' +
+            '{% endui %}' +
+            '{% endui %}',
+        buildElement(runtime) {
+            return buildTable(
+                runtime,
+                { 'aria-label': 'User list' },
+                [
+                    ['name', null, 'Name'],
+                    ['active', { align: 'center' }, 'Active'],
+                    ['total', { align: 'end' }, 'Total'],
+                    ['notes', { align: 'start' }, 'Notes'],
+                ],
+                [['Jane', 'Yes', '10', '-']]
+            );
+        },
+        meta: {},
+    },
+    {
+        name: 'column_width',
+        template:
+            '{% ui "table" aria_label="User list" %}' +
+            '{% ui "table_header" %}' +
+            '{% ui "table_column" key="name" width=96 %}Name{% endui %}' +
+            '{% endui %}' +
+            '{% ui "table_body" %}' +
+            '{% ui "table_row" %}{% ui "table_cell" %}Jane{% endui %}{% endui %}' +
+            '{% endui %}' +
+            '{% endui %}',
+        buildElement(runtime) {
+            return buildTable(
+                runtime,
+                { 'aria-label': 'User list' },
+                [['name', { width: 96 }, 'Name']],
+                [['Jane']]
+            );
+        },
+        meta: {},
+    },
+    {
+        name: 'sortable_unsorted',
+        template:
+            '{% ui "table" aria_label="User list" sort_order=request|table_sort_order %}' +
+            '{% ui "table_header" %}' +
+            '{% ui "table_column" key="name" allows_sorting=True %}Name{% endui %}' +
+            '{% ui "table_column" key="email" %}Email{% endui %}' +
+            '{% endui %}' +
+            '{% ui "table_body" %}' +
+            '{% ui "table_row" %}{% ui "table_cell" %}Jane{% endui %}{% ui "table_cell" %}jane@example.com{% endui %}{% endui %}' +
+            '{% endui %}' +
+            '{% endui %}',
+        buildElement(runtime) {
+            return buildTable(
+                runtime,
+                sortableTableProps(runtime, { sortOrder: [] }),
+                [
+                    ['name', { allowsSorting: true }, 'Name'],
+                    ['email', null, 'Email'],
+                ],
+                [['Jane', 'jane@example.com']]
+            );
+        },
+        meta: { current_url: '/users/' },
+    },
+    {
+        name: 'sortable_ascending',
+        template:
+            '{% ui "table" aria_label="User list" sort_order=request|table_sort_order %}' +
+            '{% ui "table_header" %}' +
+            '{% ui "table_column" key="name" allows_sorting=True %}Name{% endui %}' +
+            '{% endui %}' +
+            '{% ui "table_body" %}' +
+            '{% ui "table_row" %}{% ui "table_cell" %}Jane{% endui %}{% endui %}' +
+            '{% endui %}' +
+            '{% endui %}',
+        buildElement(runtime) {
+            return buildTable(
+                runtime,
+                sortableTableProps(runtime, {
+                    sortOrder: [{ column: 'name', direction: 'ascending' }],
+                }),
+                [['name', { allowsSorting: true }, 'Name']],
+                [['Jane']]
+            );
+        },
+        meta: { current_url: '/users/?ordering=name' },
+    },
+    {
+        name: 'sortable_descending',
+        template:
+            '{% ui "table" aria_label="User list" sort_order=request|table_sort_order %}' +
+            '{% ui "table_header" %}' +
+            '{% ui "table_column" key="name" allows_sorting=True %}Name{% endui %}' +
+            '{% endui %}' +
+            '{% ui "table_body" %}' +
+            '{% ui "table_row" %}{% ui "table_cell" %}Jane{% endui %}{% endui %}' +
+            '{% endui %}' +
+            '{% endui %}',
+        buildElement(runtime) {
+            return buildTable(
+                runtime,
+                sortableTableProps(runtime, {
+                    sortOrder: [{ column: 'name', direction: 'descending' }],
+                }),
+                [['name', { allowsSorting: true }, 'Name']],
+                [['Jane']]
+            );
+        },
+        meta: { current_url: '/users/?ordering=-name' },
+    },
+    {
+        name: 'multiple_sort_with_position',
+        template:
+            '{% ui "table" aria_label="User list" sort_order=request|table_sort_order sort_mode="multiple" sort_behavior="toggle" %}' +
+            '{% ui "table_header" %}' +
+            '{% ui "table_column" key="name" allows_sorting=True %}Name{% endui %}' +
+            '{% ui "table_column" key="created" allows_sorting=True %}Created{% endui %}' +
+            '{% ui "table_column" key="email" allows_sorting=True %}Email{% endui %}' +
+            '{% endui %}' +
+            '{% ui "table_body" %}' +
+            '{% ui "table_row" %}{% ui "table_cell" %}Jane{% endui %}{% ui "table_cell" %}2026-01-01{% endui %}{% ui "table_cell" %}jane@example.com{% endui %}{% endui %}' +
+            '{% endui %}' +
+            '{% endui %}',
+        buildElement(runtime) {
+            return buildTable(
+                runtime,
+                sortableTableProps(runtime, {
+                    sortOrder: [
+                        { column: 'name', direction: 'ascending' },
+                        { column: 'created', direction: 'descending' },
+                    ],
+                    sortMode: 'multiple',
+                    sortBehavior: 'toggle',
+                }),
+                [
+                    ['name', { allowsSorting: true }, 'Name'],
+                    ['created', { allowsSorting: true }, 'Created'],
+                    ['email', { allowsSorting: true }, 'Email'],
+                ],
+                [['Jane', '2026-01-01', 'jane@example.com']]
+            );
+        },
+        meta: { current_url: '/users/?page=2&ordering=name,-created' },
+    },
+    {
+        name: 'hidden_header',
+        template:
+            '{% ui "table" aria_label="User list" %}' +
+            '{% ui "table_header" %}' +
+            '{% ui "table_column" key="name" %}Name{% endui %}' +
+            '{% ui "table_column" key="actions" hide_header=True %}Actions{% endui %}' +
+            '{% endui %}' +
+            '{% ui "table_body" %}' +
+            '{% ui "table_row" %}{% ui "table_cell" %}Jane{% endui %}{% ui "table_cell" %}Edit{% endui %}{% endui %}' +
+            '{% endui %}' +
+            '{% endui %}',
+        buildElement(runtime) {
+            return buildTable(
+                runtime,
+                { 'aria-label': 'User list' },
+                [
+                    ['name', null, 'Name'],
+                    ['actions', { hideHeader: true }, 'Actions'],
+                ],
+                [['Jane', 'Edit']]
+            );
+        },
+        meta: {},
+    },
+    {
+        name: 'empty_body_default_empty_state',
+        template:
+            '{% ui "table" aria_label="User list" %}' +
+            '{% ui "table_header" %}' +
+            '{% ui "table_column" key="name" %}Name{% endui %}' +
+            '{% ui "table_column" key="email" %}Email{% endui %}' +
+            '{% endui %}' +
+            '{% ui "table_body" %}{% endui %}' +
+            '{% endui %}',
+        buildElement(runtime) {
+            return buildTable(
+                runtime,
+                { 'aria-label': 'User list' },
+                [
+                    ['name', null, 'Name'],
+                    ['email', null, 'Email'],
+                ],
+                []
+            );
+        },
+        meta: {},
+    },
+    {
+        name: 'empty_body_empty_state_disabled',
+        template:
+            '{% ui "table" aria_label="User list" render_empty_state=None %}' +
+            '{% ui "table_header" %}' +
+            '{% ui "table_column" key="name" %}Name{% endui %}' +
+            '{% endui %}' +
+            '{% ui "table_body" %}{% endui %}' +
+            '{% endui %}',
+        buildElement(runtime) {
+            return buildTable(
+                runtime,
+                { 'aria-label': 'User list', renderEmptyState: null },
+                [['name', null, 'Name']],
+                []
+            );
+        },
+        meta: {},
+    },
+    {
+        name: 'header_footer_content',
+        template:
+            '{% ui "table" aria_label="User list" header="Showing 1 user" footer="Page 1 of 1" %}' +
+            '{% ui "table_header" %}' +
+            '{% ui "table_column" key="name" %}Name{% endui %}' +
+            '{% endui %}' +
+            '{% ui "table_body" %}' +
+            '{% ui "table_row" %}{% ui "table_cell" %}Jane{% endui %}{% endui %}' +
+            '{% endui %}' +
+            '{% endui %}',
+        buildElement(runtime) {
+            return buildTable(
+                runtime,
+                { 'aria-label': 'User list', header: 'Showing 1 user', footer: 'Page 1 of 1' },
+                [['name', null, 'Name']],
+                [['Jane']]
+            );
+        },
+        meta: {},
+    },
+];

--- a/packages/ap-ui/tests/fixtures/ui_html_table_parity.json
+++ b/packages/ap-ui/tests/fixtures/ui_html_table_parity.json
@@ -1,0 +1,100 @@
+{
+  "generated_by": "scripts/generateHtmlUiParityFixtures.mjs",
+  "generated_at_utc": "2026-07-07T06:04:01.138Z",
+  "component": "table",
+  "styles": {},
+  "cases": [
+    {
+      "name": "basic",
+      "template": "{% ui \"table\" aria_label=\"User list\" %}{% ui \"table_header\" %}{% ui \"table_column\" key=\"name\" %}Name{% endui %}{% ui \"table_column\" key=\"email\" %}Email{% endui %}{% endui %}{% ui \"table_body\" %}{% ui \"table_row\" %}{% ui \"table_cell\" %}Jane{% endui %}{% ui \"table_cell\" %}jane@example.com{% endui %}{% endui %}{% ui \"table_row\" %}{% ui \"table_cell\" %}John{% endui %}{% ui \"table_cell\" %}john@example.com{% endui %}{% endui %}{% endui %}{% endui %}",
+      "expected_html": "<div data-apui=\"table\" data-mode=\"default\" class=\"Table_wrapper Table_hasNoHeader Table_hasNoFooter\"><div class=\"Table_scrollContainer\"><table aria-label=\"User list\"><thead><tr class=\"Table_headerRow\"><th scope=\"col\" class=\"Table_headerCell\"><div class=\"Table_headerCellWrapper\"><div class=\"Table_headerCellContent\">Name</div></div></th><th scope=\"col\" class=\"Table_headerCell\"><div class=\"Table_headerCellWrapper\"><div class=\"Table_headerCellContent\">Email</div></div></th></tr></thead><tbody><tr class=\"Table_row\"><td role=\"rowheader\" class=\"Table_cell\">Jane</td><td class=\"Table_cell\">jane@example.com</td></tr><tr class=\"Table_row\"><td role=\"rowheader\" class=\"Table_cell\">John</td><td class=\"Table_cell\">john@example.com</td></tr></tbody></table></div></div>",
+      "expected_warnings": [],
+      "meta": {}
+    },
+    {
+      "name": "class_style_merging",
+      "template": "{% ui \"table\" aria_label=\"User list\" class=\"custom-table\" style=\"max-width: 400px\" %}{% ui \"table_header\" %}{% ui \"table_column\" key=\"name\" class=\"custom-column\" %}Name{% endui %}{% endui %}{% ui \"table_body\" class=\"custom-body\" %}{% ui \"table_row\" class=\"custom-row\" %}{% ui \"table_cell\" class=\"custom-cell\" style=\"font-style: italic\" %}Jane{% endui %}{% endui %}{% endui %}{% endui %}",
+      "expected_html": "<div data-apui=\"table\" data-mode=\"default\" class=\"Table_wrapper custom-table Table_hasNoHeader Table_hasNoFooter\" style=\"max-width: 400px\"><div class=\"Table_scrollContainer\"><table aria-label=\"User list\"><thead><tr class=\"Table_headerRow\"><th scope=\"col\" class=\"custom-column Table_headerCell\"><div class=\"Table_headerCellWrapper\"><div class=\"Table_headerCellContent\">Name</div></div></th></tr></thead><tbody class=\"custom-body\"><tr class=\"custom-row Table_row\"><td role=\"rowheader\" class=\"Table_cell custom-cell\" style=\"font-style: italic\">Jane</td></tr></tbody></table></div></div>",
+      "expected_warnings": [],
+      "meta": {}
+    },
+    {
+      "name": "column_alignment",
+      "template": "{% ui \"table\" aria_label=\"User list\" %}{% ui \"table_header\" %}{% ui \"table_column\" key=\"name\" %}Name{% endui %}{% ui \"table_column\" key=\"active\" align=\"center\" %}Active{% endui %}{% ui \"table_column\" key=\"total\" align=\"end\" %}Total{% endui %}{% ui \"table_column\" key=\"notes\" align=\"start\" %}Notes{% endui %}{% endui %}{% ui \"table_body\" %}{% ui \"table_row\" %}{% ui \"table_cell\" %}Jane{% endui %}{% ui \"table_cell\" %}Yes{% endui %}{% ui \"table_cell\" %}10{% endui %}{% ui \"table_cell\" %}-{% endui %}{% endui %}{% endui %}{% endui %}",
+      "expected_html": "<div data-apui=\"table\" data-mode=\"default\" class=\"Table_wrapper Table_hasNoHeader Table_hasNoFooter\"><div class=\"Table_scrollContainer\"><table aria-label=\"User list\"><thead><tr class=\"Table_headerRow\"><th scope=\"col\" class=\"Table_headerCell\"><div class=\"Table_headerCellWrapper\"><div class=\"Table_headerCellContent\">Name</div></div></th><th scope=\"col\" class=\"Table_headerCell\" data-align=\"center\"><div class=\"Table_headerCellWrapper\"><div class=\"Table_headerCellContent\">Active</div></div></th><th scope=\"col\" class=\"Table_headerCell Table_alignEnd\" data-align=\"end\"><div class=\"Table_headerCellWrapper\"><div class=\"Table_headerCellContent\">Total</div></div></th><th scope=\"col\" class=\"Table_headerCell\" data-align=\"start\"><div class=\"Table_headerCellWrapper\"><div class=\"Table_headerCellContent\">Notes</div></div></th></tr></thead><tbody><tr class=\"Table_row\"><td role=\"rowheader\" class=\"Table_cell\">Jane</td><td class=\"Table_cell Table_alignCenter\" data-align=\"center\">Yes</td><td class=\"Table_cell Table_alignEnd\" data-align=\"end\">10</td><td class=\"Table_cell\" data-align=\"start\">-</td></tr></tbody></table></div></div>",
+      "expected_warnings": [],
+      "meta": {}
+    },
+    {
+      "name": "column_width",
+      "template": "{% ui \"table\" aria_label=\"User list\" %}{% ui \"table_header\" %}{% ui \"table_column\" key=\"name\" width=96 %}Name{% endui %}{% endui %}{% ui \"table_body\" %}{% ui \"table_row\" %}{% ui \"table_cell\" %}Jane{% endui %}{% endui %}{% endui %}{% endui %}",
+      "expected_html": "<div data-apui=\"table\" data-mode=\"default\" class=\"Table_wrapper Table_hasNoHeader Table_hasNoFooter\"><div class=\"Table_scrollContainer\"><table aria-label=\"User list\"><thead><tr class=\"Table_headerRow\"><th scope=\"col\" class=\"Table_headerCell\" style=\"--components-table-columnWidth: 96px\"><div class=\"Table_headerCellWrapper\"><div class=\"Table_headerCellContent\">Name</div></div></th></tr></thead><tbody><tr class=\"Table_row\"><td role=\"rowheader\" class=\"Table_cell\">Jane</td></tr></tbody></table></div></div>",
+      "expected_warnings": [],
+      "meta": {}
+    },
+    {
+      "name": "sortable_unsorted",
+      "template": "{% ui \"table\" aria_label=\"User list\" sort_order=request|table_sort_order %}{% ui \"table_header\" %}{% ui \"table_column\" key=\"name\" allows_sorting=True %}Name{% endui %}{% ui \"table_column\" key=\"email\" %}Email{% endui %}{% endui %}{% ui \"table_body\" %}{% ui \"table_row\" %}{% ui \"table_cell\" %}Jane{% endui %}{% ui \"table_cell\" %}jane@example.com{% endui %}{% endui %}{% endui %}{% endui %}",
+      "expected_html": "<div data-apui=\"table\" data-mode=\"default\" class=\"Table_wrapper Table_hasNoHeader Table_hasNoFooter\"><div class=\"Table_scrollContainer\"><table aria-label=\"User list\"><thead><tr class=\"Table_headerRow\"><th scope=\"col\" aria-sort=\"none\" class=\"Table_headerCell\"><div class=\"Table_headerCellWrapper\"><a class=\"Table_headerCellContent\" href=\"/users/?ordering=name\">Name</a><span class=\"Table_sortWrapper\"><span aria-hidden=\"true\" role=\"img\" class=\"Icon_icon Icon_variants_plain Icon_sizes_xs Table_sortIconUnsorted Table_sortIcon\"><svg width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\" focusable=\"false\"><path d=\"M12 19V5M12 5L5 12M12 5L19 12\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"></path></svg></span></span></div></th><th scope=\"col\" class=\"Table_headerCell\"><div class=\"Table_headerCellWrapper\"><div class=\"Table_headerCellContent\">Email</div></div></th></tr></thead><tbody><tr class=\"Table_row\"><td role=\"rowheader\" class=\"Table_cell\">Jane</td><td class=\"Table_cell\">jane@example.com</td></tr></tbody></table></div></div>",
+      "expected_warnings": [],
+      "meta": {
+        "current_url": "/users/"
+      }
+    },
+    {
+      "name": "sortable_ascending",
+      "template": "{% ui \"table\" aria_label=\"User list\" sort_order=request|table_sort_order %}{% ui \"table_header\" %}{% ui \"table_column\" key=\"name\" allows_sorting=True %}Name{% endui %}{% endui %}{% ui \"table_body\" %}{% ui \"table_row\" %}{% ui \"table_cell\" %}Jane{% endui %}{% endui %}{% endui %}{% endui %}",
+      "expected_html": "<div data-apui=\"table\" data-mode=\"default\" class=\"Table_wrapper Table_hasNoHeader Table_hasNoFooter\"><div class=\"Table_scrollContainer\"><table aria-label=\"User list\"><thead><tr class=\"Table_headerRow\"><th scope=\"col\" aria-sort=\"ascending\" class=\"Table_headerCell\" data-sort-direction=\"ascending\"><div class=\"Table_headerCellWrapper\"><a class=\"Table_headerCellContent\" href=\"/users/?ordering=-name\">Name</a><span class=\"Table_sortWrapper\"><span aria-hidden=\"true\" role=\"img\" class=\"Icon_icon Icon_variants_plain Icon_sizes_xs Table_sortIcon\"><svg width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\" focusable=\"false\"><path d=\"M12 19V5M12 5L5 12M12 5L19 12\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"></path></svg></span></span></div></th></tr></thead><tbody><tr class=\"Table_row\"><td role=\"rowheader\" class=\"Table_cell\">Jane</td></tr></tbody></table></div></div>",
+      "expected_warnings": [],
+      "meta": {
+        "current_url": "/users/?ordering=name"
+      }
+    },
+    {
+      "name": "sortable_descending",
+      "template": "{% ui \"table\" aria_label=\"User list\" sort_order=request|table_sort_order %}{% ui \"table_header\" %}{% ui \"table_column\" key=\"name\" allows_sorting=True %}Name{% endui %}{% endui %}{% ui \"table_body\" %}{% ui \"table_row\" %}{% ui \"table_cell\" %}Jane{% endui %}{% endui %}{% endui %}{% endui %}",
+      "expected_html": "<div data-apui=\"table\" data-mode=\"default\" class=\"Table_wrapper Table_hasNoHeader Table_hasNoFooter\"><div class=\"Table_scrollContainer\"><table aria-label=\"User list\"><thead><tr class=\"Table_headerRow\"><th scope=\"col\" aria-sort=\"descending\" class=\"Table_headerCell\" data-sort-direction=\"descending\"><div class=\"Table_headerCellWrapper\"><a class=\"Table_headerCellContent\" href=\"/users/\">Name</a><span class=\"Table_sortWrapper\"><span aria-hidden=\"true\" role=\"img\" class=\"Icon_icon Icon_variants_plain Icon_sizes_xs Table_sortIcon\"><svg width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\" focusable=\"false\"><path d=\"M12 5V19M12 19L19 12M12 19L5 12\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"></path></svg></span></span></div></th></tr></thead><tbody><tr class=\"Table_row\"><td role=\"rowheader\" class=\"Table_cell\">Jane</td></tr></tbody></table></div></div>",
+      "expected_warnings": [],
+      "meta": {
+        "current_url": "/users/?ordering=-name"
+      }
+    },
+    {
+      "name": "multiple_sort_with_position",
+      "template": "{% ui \"table\" aria_label=\"User list\" sort_order=request|table_sort_order sort_mode=\"multiple\" sort_behavior=\"toggle\" %}{% ui \"table_header\" %}{% ui \"table_column\" key=\"name\" allows_sorting=True %}Name{% endui %}{% ui \"table_column\" key=\"created\" allows_sorting=True %}Created{% endui %}{% ui \"table_column\" key=\"email\" allows_sorting=True %}Email{% endui %}{% endui %}{% ui \"table_body\" %}{% ui \"table_row\" %}{% ui \"table_cell\" %}Jane{% endui %}{% ui \"table_cell\" %}2026-01-01{% endui %}{% ui \"table_cell\" %}jane@example.com{% endui %}{% endui %}{% endui %}{% endui %}",
+      "expected_html": "<div data-apui=\"table\" data-mode=\"default\" class=\"Table_wrapper Table_hasNoHeader Table_hasNoFooter\"><div class=\"Table_scrollContainer\"><table aria-label=\"User list\"><thead><tr class=\"Table_headerRow\"><th scope=\"col\" aria-sort=\"ascending\" class=\"Table_headerCell\" data-sort-direction=\"ascending\"><div class=\"Table_headerCellWrapper\"><a class=\"Table_headerCellContent\" href=\"/users/?page=2&amp;ordering=-name%2C-created\">Name</a><span class=\"Table_sortWrapper\"><span aria-hidden=\"true\" role=\"img\" class=\"Icon_icon Icon_variants_plain Icon_sizes_xs Table_sortIcon\"><svg width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\" focusable=\"false\"><path d=\"M12 19V5M12 5L5 12M12 5L19 12\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"></path></svg></span><span>1</span></span></div></th><th scope=\"col\" aria-sort=\"descending\" class=\"Table_headerCell\" data-sort-direction=\"descending\"><div class=\"Table_headerCellWrapper\"><a class=\"Table_headerCellContent\" href=\"/users/?page=2&amp;ordering=name\">Created</a><span class=\"Table_sortWrapper\"><span aria-hidden=\"true\" role=\"img\" class=\"Icon_icon Icon_variants_plain Icon_sizes_xs Table_sortIcon\"><svg width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\" focusable=\"false\"><path d=\"M12 5V19M12 19L19 12M12 19L5 12\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"></path></svg></span><span>2</span></span></div></th><th scope=\"col\" aria-sort=\"none\" class=\"Table_headerCell\"><div class=\"Table_headerCellWrapper\"><a class=\"Table_headerCellContent\" href=\"/users/?page=2&amp;ordering=name%2C-created%2Cemail\">Email</a><span class=\"Table_sortWrapper\"><span aria-hidden=\"true\" role=\"img\" class=\"Icon_icon Icon_variants_plain Icon_sizes_xs Table_sortIconUnsorted Table_sortIcon\"><svg width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\" focusable=\"false\"><path d=\"M12 19V5M12 5L5 12M12 5L19 12\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"></path></svg></span><span></span></span></div></th></tr></thead><tbody><tr class=\"Table_row\"><td role=\"rowheader\" class=\"Table_cell\">Jane</td><td class=\"Table_cell\">2026-01-01</td><td class=\"Table_cell\">jane@example.com</td></tr></tbody></table></div></div>",
+      "expected_warnings": [],
+      "meta": {
+        "current_url": "/users/?page=2&ordering=name,-created"
+      }
+    },
+    {
+      "name": "hidden_header",
+      "template": "{% ui \"table\" aria_label=\"User list\" %}{% ui \"table_header\" %}{% ui \"table_column\" key=\"name\" %}Name{% endui %}{% ui \"table_column\" key=\"actions\" hide_header=True %}Actions{% endui %}{% endui %}{% ui \"table_body\" %}{% ui \"table_row\" %}{% ui \"table_cell\" %}Jane{% endui %}{% ui \"table_cell\" %}Edit{% endui %}{% endui %}{% endui %}{% endui %}",
+      "expected_html": "<div data-apui=\"table\" data-mode=\"default\" class=\"Table_wrapper Table_hasNoHeader Table_hasNoFooter\"><div class=\"Table_scrollContainer\"><table aria-label=\"User list\"><thead><tr class=\"Table_headerRow\"><th scope=\"col\" class=\"Table_headerCell\"><div class=\"Table_headerCellWrapper\"><div class=\"Table_headerCellContent\">Name</div></div></th><th scope=\"col\" class=\"Table_headerCell\"><div class=\"Table_headerCellWrapper\"><div style=\"border: 0; clip: rect(0 0 0 0); clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0; position: absolute; width: 1px; white-space: nowrap\"><div class=\"Table_headerCellContent\">Actions</div></div></div></th></tr></thead><tbody><tr class=\"Table_row\"><td role=\"rowheader\" class=\"Table_cell\">Jane</td><td class=\"Table_cell\">Edit</td></tr></tbody></table></div></div>",
+      "expected_warnings": [],
+      "meta": {}
+    },
+    {
+      "name": "empty_body_default_empty_state",
+      "template": "{% ui \"table\" aria_label=\"User list\" %}{% ui \"table_header\" %}{% ui \"table_column\" key=\"name\" %}Name{% endui %}{% ui \"table_column\" key=\"email\" %}Email{% endui %}{% endui %}{% ui \"table_body\" %}{% endui %}{% endui %}",
+      "expected_html": "<div data-apui=\"table\" data-mode=\"default\" class=\"Table_wrapper Table_hasNoHeader Table_hasNoFooter\"><div class=\"Table_scrollContainer\"><table aria-label=\"User list\"><thead><tr class=\"Table_headerRow\"><th scope=\"col\" class=\"Table_headerCell\"><div class=\"Table_headerCellWrapper\"><div class=\"Table_headerCellContent\">Name</div></div></th><th scope=\"col\" class=\"Table_headerCell\"><div class=\"Table_headerCellWrapper\"><div class=\"Table_headerCellContent\">Email</div></div></th></tr></thead><tbody><tr><td colspan=\"2\"><div class=\"Table_noResults\"><em>No results</em></div></td></tr></tbody></table></div></div>",
+      "expected_warnings": [],
+      "meta": {}
+    },
+    {
+      "name": "empty_body_empty_state_disabled",
+      "template": "{% ui \"table\" aria_label=\"User list\" render_empty_state=None %}{% ui \"table_header\" %}{% ui \"table_column\" key=\"name\" %}Name{% endui %}{% endui %}{% ui \"table_body\" %}{% endui %}{% endui %}",
+      "expected_html": "<div data-apui=\"table\" data-mode=\"default\" class=\"Table_wrapper Table_hasNoHeader Table_hasNoFooter\"><div class=\"Table_scrollContainer\"><table aria-label=\"User list\"><thead><tr class=\"Table_headerRow\"><th scope=\"col\" class=\"Table_headerCell\"><div class=\"Table_headerCellWrapper\"><div class=\"Table_headerCellContent\">Name</div></div></th></tr></thead><tbody></tbody></table></div></div>",
+      "expected_warnings": [],
+      "meta": {}
+    },
+    {
+      "name": "header_footer_content",
+      "template": "{% ui \"table\" aria_label=\"User list\" header=\"Showing 1 user\" footer=\"Page 1 of 1\" %}{% ui \"table_header\" %}{% ui \"table_column\" key=\"name\" %}Name{% endui %}{% endui %}{% ui \"table_body\" %}{% ui \"table_row\" %}{% ui \"table_cell\" %}Jane{% endui %}{% endui %}{% endui %}{% endui %}",
+      "expected_html": "<div data-apui=\"table\" data-mode=\"default\" data-has-header=\"true\" data-has-footer=\"true\" class=\"Table_wrapper Table_hasHeader\">Showing 1 user<div class=\"Table_scrollContainer\"><table aria-label=\"User list\"><thead><tr class=\"Table_headerRow\"><th scope=\"col\" class=\"Table_headerCell\"><div class=\"Table_headerCellWrapper\"><div class=\"Table_headerCellContent\">Name</div></div></th></tr></thead><tbody><tr class=\"Table_row\"><td role=\"rowheader\" class=\"Table_cell\">Jane</td></tr></tbody></table></div>Page 1 of 1</div>",
+      "expected_warnings": [],
+      "meta": {}
+    }
+  ]
+}

--- a/packages/ap-ui/tests/parity/style_mocks.py
+++ b/packages/ap-ui/tests/parity/style_mocks.py
@@ -44,6 +44,16 @@ DEFAULT_STYLE_MAPPINGS: dict[str, dict[str, Any]] = {
             "vertical": "SmartOrientation_containerBase",
         },
     },
+    "Table.css.ts": {
+        # The theme contract vars are serialized as var() references; only columnWidth is used
+        # by the static renderer (for the column width prop).
+        "vars": {
+            "columnWidth": "var(--components-table-columnWidth)",
+        },
+        # sortIconUnsorted is composed from sortIcon (style([sortIcon, ...])) so the serialized
+        # mapping value contains both classes.
+        "sortIconUnsorted": "Table_sortIconUnsorted Table_sortIcon",
+    },
     "LabeledInput.css.ts": {
         # Mirrors the recipe structure serialized by @alliancesoftware/vite-plugin-django-vanilla-extract
         "labeledInput": {

--- a/packages/ap-ui/tests/test_alliance_ui_form.py
+++ b/packages/ap-ui/tests/test_alliance_ui_form.py
@@ -117,19 +117,21 @@ class FormRenderingTestCase(TestCase):
     def test_form_input_requires_renderer(self):
         user = self.get_user()
 
-        with self.setup_overrides():
-            with override_settings(FORM_RENDERER="django.forms.renderers.DjangoTemplates"):
-                with self.assertWarns(
-                    UserWarning,
-                    msg="form_input tag should only be used with 'FormInputContextRenderer'",
-                ):
-                    self.client.get(reverse("update_user", kwargs={"pk": user.pk}), follow=True)
-
-        # IMPORTANT: Clear the form renderer cache after overriding settings
-        # Django 4.2+ caches the renderer with @lru_cache which persists across tests
         from django.forms.renderers import get_default_renderer
 
-        get_default_renderer.cache_clear()
+        with self.setup_overrides():
+            with override_settings(FORM_RENDERER="django.forms.renderers.DjangoTemplates"):
+                # Django 4.2 caches the default renderer with @lru_cache and
+                # doesn't clear it when FORM_RENDERER is overridden.
+                get_default_renderer.cache_clear()
+                try:
+                    with self.assertWarns(
+                        UserWarning,
+                        msg="form_input tag should only be used with 'FormInputContextRenderer'",
+                    ):
+                        self.client.get(reverse("update_user", kwargs={"pk": user.pk}), follow=True)
+                finally:
+                    get_default_renderer.cache_clear()
 
     def test_renderer_handles_context_key(self):
         user = self.get_user()

--- a/packages/ap-ui/tests/test_html_ui_table_components.py
+++ b/packages/ap-ui/tests/test_html_ui_table_components.py
@@ -1,0 +1,702 @@
+from __future__ import annotations
+
+import warnings
+
+from django.template import Context
+from django.template import Template
+from django.test import RequestFactory
+
+from tests.parity.base import HtmlUIParityTestCase
+
+BASIC_TABLE_TEMPLATE = (
+    '{% ui "table" aria_label="User list" %}'
+    '{% ui "table_header" %}'
+    '{% ui "table_column" key="name" %}Name{% endui %}'
+    '{% ui "table_column" key="email" %}Email{% endui %}'
+    "{% endui %}"
+    '{% ui "table_body" %}'
+    '{% ui "table_row" key=1 %}'
+    '{% ui "table_cell" %}Jane{% endui %}'
+    '{% ui "table_cell" %}jane@example.com{% endui %}'
+    "{% endui %}"
+    "{% endui %}"
+    "{% endui %}"
+)
+
+
+def make_sortable_table_template(
+    table_props: str = "", columns: str | None = None, cells: str | None = None
+) -> str:
+    if columns is None:
+        columns = (
+            '{% ui "table_column" key="name" allows_sorting=True %}Name{% endui %}'
+            '{% ui "table_column" key="email" allows_sorting=True %}Email{% endui %}'
+        )
+    if cells is None:
+        cells = '{% ui "table_cell" %}Jane{% endui %}' * columns.count("table_column")
+    return (
+        '{% ui "table" aria_label="User list" ' + table_props + " %}"
+        '{% ui "table_header" %}' + columns + "{% endui %}"
+        '{% ui "table_body" %}{% ui "table_row" %}' + cells + "{% endui %}{% endui %}"
+        "{% endui %}"
+    )
+
+
+class UITableComponentsTestCase(HtmlUIParityTestCase):
+    """Unit tests for the static table components not covered by the parity fixtures."""
+
+    request_factory = RequestFactory()
+
+    def render_with_warnings(self, template_body: str, context_kwargs=None):
+        with self.setup_render_context():
+            with warnings.catch_warnings(record=True) as caught_warnings:
+                warnings.simplefilter("always")
+                output = self.render_ui_template(template_body, context_kwargs)
+        return output, [str(item.message) for item in caught_warnings]
+
+    def test_table_renders_full_structure(self):
+        output, caught = self.render_with_warnings(BASIC_TABLE_TEMPLATE)
+        self.assertEqual(caught, [])
+        self.assertIn(
+            '<div data-apui="table" data-mode="default" '
+            'class="Table_wrapper Table_hasNoHeader Table_hasNoFooter">',
+            output,
+        )
+        self.assertIn('<div class="Table_scrollContainer"><table aria-label="User list">', output)
+        self.assertIn('<thead><tr class="Table_headerRow">', output)
+        self.assertIn(
+            '<th class="Table_headerCell" scope="col">'
+            '<div class="Table_headerCellWrapper"><div class="Table_headerCellContent">Name</div></div>'
+            "</th>",
+            output,
+        )
+        self.assertIn("<tbody>", output)
+        self.assertIn('<tr class="Table_row" data-key="1">', output)
+        self.assertIn('<td class="Table_cell" role="rowheader">Jane</td>', output)
+        self.assertIn('<td class="Table_cell">jane@example.com</td>', output)
+        # No ARIA grid behaviour is rendered by the static implementation
+        self.assertNotIn('role="grid"', output)
+        self.assertNotIn("tabindex", output)
+
+    def test_class_kwargs_merge_with_default_classes(self):
+        template = (
+            '{% ui "table" aria_label="Users" class="my-table" %}'
+            '{% ui "table_header" %}'
+            '{% ui "table_column" class="my-column" %}Name{% endui %}'
+            "{% endui %}"
+            '{% ui "table_body" class="my-body" %}'
+            '{% ui "table_row" class="my-row" %}'
+            '{% ui "table_cell" class="my-cell" %}Jane{% endui %}'
+            "{% endui %}"
+            "{% endui %}"
+            "{% endui %}"
+        )
+        output, caught = self.render_with_warnings(template)
+        self.assertEqual(caught, [])
+        self.assertIn('class="Table_wrapper my-table Table_hasNoHeader Table_hasNoFooter"', output)
+        # Header cells and rows merge the user class before the default classes (matching the
+        # React mergeProps ordering); body cells merge it after.
+        self.assertIn('class="my-column Table_headerCell"', output)
+        self.assertIn('<tbody class="my-body">', output)
+        self.assertIn('class="my-row Table_row"', output)
+        self.assertIn('class="Table_cell my-cell"', output)
+
+    def test_column_align_applies_to_header_and_body_cells(self):
+        template = (
+            '{% ui "table" aria_label="Users" %}'
+            '{% ui "table_header" %}'
+            '{% ui "table_column" %}Name{% endui %}'
+            '{% ui "table_column" align="center" %}Active{% endui %}'
+            '{% ui "table_column" align="end" %}Total{% endui %}'
+            '{% ui "table_column" align="start" %}Notes{% endui %}'
+            "{% endui %}"
+            '{% ui "table_body" %}'
+            '{% ui "table_row" %}'
+            '{% ui "table_cell" %}Jane{% endui %}'
+            '{% ui "table_cell" %}Yes{% endui %}'
+            '{% ui "table_cell" %}10{% endui %}'
+            '{% ui "table_cell" %}-{% endui %}'
+            "{% endui %}"
+            "{% endui %}"
+            "{% endui %}"
+        )
+        output, caught = self.render_with_warnings(template)
+        self.assertEqual(caught, [])
+        # center: data attribute on the header, alignCenter class only on the body cell (the React
+        # implementation does not apply alignCenter to header cells)
+        self.assertIn('<th class="Table_headerCell" data-align="center" scope="col">', output)
+        self.assertIn('<td class="Table_cell Table_alignCenter" data-align="center">Yes</td>', output)
+        # end: alignEnd class on both header and body cell
+        self.assertIn('<th class="Table_headerCell Table_alignEnd" data-align="end" scope="col">', output)
+        self.assertIn('<td class="Table_cell Table_alignEnd" data-align="end">10</td>', output)
+        # start: data attribute only, no extra class
+        self.assertIn('<th class="Table_headerCell" data-align="start" scope="col">', output)
+        self.assertIn('<td class="Table_cell" data-align="start">-</td>', output)
+
+    def test_invalid_align_warns_and_is_ignored(self):
+        template = make_sortable_table_template(
+            columns='{% ui "table_column" align="middle" %}Name{% endui %}'
+        )
+        output, caught = self.render_with_warnings(template)
+        self.assertIn("Invalid 'align' prop passed: middle", caught)
+        self.assertNotIn("data-align", output)
+
+    def test_first_column_is_row_header_by_default(self):
+        output, _ = self.render_with_warnings(BASIC_TABLE_TEMPLATE)
+        self.assertIn('<td class="Table_cell" role="rowheader">Jane</td>', output)
+        self.assertNotIn('role="rowheader">jane@example.com', output)
+
+    def test_explicit_is_row_header_overrides_first_column_default(self):
+        template = (
+            '{% ui "table" aria_label="Users" %}'
+            '{% ui "table_header" %}'
+            '{% ui "table_column" %}Name{% endui %}'
+            '{% ui "table_column" is_row_header=True %}Email{% endui %}'
+            "{% endui %}"
+            '{% ui "table_body" %}'
+            '{% ui "table_row" %}'
+            '{% ui "table_cell" %}Jane{% endui %}'
+            '{% ui "table_cell" %}jane@example.com{% endui %}'
+            "{% endui %}"
+            "{% endui %}"
+            "{% endui %}"
+        )
+        output, caught = self.render_with_warnings(template)
+        self.assertEqual(caught, [])
+        self.assertIn('<td class="Table_cell">Jane</td>', output)
+        self.assertIn('<td class="Table_cell" role="rowheader">jane@example.com</td>', output)
+
+    def test_column_width_renders_css_variable(self):
+        template = make_sortable_table_template(columns='{% ui "table_column" width=96 %}Name{% endui %}')
+        output, caught = self.render_with_warnings(template)
+        self.assertEqual(caught, [])
+        self.assertIn('style="--components-table-columnWidth: 96px"', output)
+
+    def test_column_width_string_value_used_verbatim(self):
+        template = make_sortable_table_template(columns='{% ui "table_column" width="20%" %}Name{% endui %}')
+        output, _ = self.render_with_warnings(template)
+        self.assertIn('style="--components-table-columnWidth: 20%"', output)
+
+    def test_hide_header_renders_visually_hidden_content(self):
+        template = make_sortable_table_template(
+            columns='{% ui "table_column" hide_header=True %}Actions{% endui %}'
+        )
+        output, caught = self.render_with_warnings(template)
+        self.assertEqual(caught, [])
+        self.assertIn(
+            '<div style="border: 0; clip: rect(0 0 0 0); clip-path: inset(50%); height: 1px; '
+            "margin: -1px; overflow: hidden; padding: 0; position: absolute; width: 1px; "
+            'white-space: nowrap"><div class="Table_headerCellContent">Actions</div></div>',
+            output,
+        )
+
+    # --- Sorting ---
+
+    def test_sort_links_preserve_unrelated_query_params(self):
+        request = self.request_factory.get("/users/?page=2&search=jane")
+        template = make_sortable_table_template()
+        output, caught = self.render_with_warnings(template, {"request": request})
+        self.assertEqual(caught, [])
+        self.assertIn('href="/users/?page=2&amp;search=jane&amp;ordering=name"', output)
+
+    def test_sort_cycle_ascending_to_descending_to_off(self):
+        template = make_sortable_table_template('sort_order=request|table_sort_order sort_mode="single"')
+        # Unsorted -> ascending
+        request = self.request_factory.get("/users/")
+        output, _ = self.render_with_warnings(template, {"request": request})
+        self.assertIn('href="/users/?ordering=name"', output)
+        # Ascending -> descending
+        request = self.request_factory.get("/users/?ordering=name")
+        output, _ = self.render_with_warnings(template, {"request": request})
+        self.assertIn('href="/users/?ordering=-name"', output)
+        self.assertIn('aria-sort="ascending"', output)
+        self.assertIn('data-sort-direction="ascending"', output)
+        # Descending -> off
+        request = self.request_factory.get("/users/?ordering=-name")
+        output, _ = self.render_with_warnings(template, {"request": request})
+        self.assertIn('href="/users/"', output)
+        self.assertIn('aria-sort="descending"', output)
+        self.assertIn('data-sort-direction="descending"', output)
+
+    def test_sort_mode_single_replaces_other_descriptors(self):
+        request = self.request_factory.get("/users/?ordering=-email")
+        template = make_sortable_table_template('sort_order=request|table_sort_order sort_mode="single"')
+        output, _ = self.render_with_warnings(template, {"request": request})
+        # Clicking name only sorts by name; email descriptor is dropped
+        self.assertIn('href="/users/?ordering=name"', output)
+
+    def test_sort_mode_multiple_toggle_preserves_other_descriptors(self):
+        request = self.request_factory.get("/users/?page=2&order=-name")
+        template = make_sortable_table_template(
+            'sort_order=request|table_sort_order:"order" sort_query_param="order" '
+            'sort_mode="multiple" sort_behavior="toggle"'
+        )
+        output, caught = self.render_with_warnings(template, {"request": request})
+        self.assertEqual(caught, [])
+        # name is descending -> clicking it cycles off, keeping other params
+        self.assertIn('href="/users/?page=2"', output)
+        # email is unsorted -> clicking it appends to the existing order
+        self.assertIn('href="/users/?page=2&amp;order=-name%2Cemail"', output)
+
+    def test_sort_mode_multiple_replace_replaces_other_descriptors(self):
+        request = self.request_factory.get("/users/?page=2&order=-name")
+        template = make_sortable_table_template(
+            'sort_order=request|table_sort_order:"order" sort_query_param="order" '
+            'sort_mode="multiple" sort_behavior="replace"'
+        )
+        output, caught = self.render_with_warnings(template, {"request": request})
+        self.assertEqual(caught, [])
+        # email is unsorted -> clicking it replaces the whole order (no meta/ctrl toggle statically)
+        self.assertIn('href="/users/?page=2&amp;order=email"', output)
+        # name is descending -> clicking it cycles off
+        self.assertIn('href="/users/?page=2"', output)
+
+    def test_explicit_sort_href_bypasses_url_generation(self):
+        template = make_sortable_table_template(
+            columns=(
+                '{% ui "table_column" allows_sorting=True sort_href="?order=-created_at" '
+                'sort_direction="ascending" %}Created{% endui %}'
+            )
+        )
+        output, caught = self.render_with_warnings(template)
+        self.assertEqual(caught, [])
+        self.assertIn('<a class="Table_headerCellContent" href="?order=-created_at">Created</a>', output)
+        self.assertIn('aria-sort="ascending"', output)
+        self.assertIn('data-sort-direction="ascending"', output)
+
+    def test_sortable_column_without_url_warns_and_renders_non_link(self):
+        template = make_sortable_table_template()
+        output, caught = self.render_with_warnings(template)
+        self.assertTrue(any("Could not build a sort URL for column 'name'" in item for item in caught))
+        self.assertNotIn("<a ", output)
+        # Sort styling/state still renders
+        self.assertIn('aria-sort="none"', output)
+        self.assertIn('<div class="Table_headerCellContent">Name</div>', output)
+        self.assertIn("Table_sortIconUnsorted", output)
+
+    def test_sort_icons_match_sort_state(self):
+        request = self.request_factory.get("/users/?ordering=name,-email")
+        template = make_sortable_table_template(
+            'sort_order=request|table_sort_order sort_mode="multiple"',
+            columns=(
+                '{% ui "table_column" key="name" allows_sorting=True %}Name{% endui %}'
+                '{% ui "table_column" key="email" allows_sorting=True %}Email{% endui %}'
+                '{% ui "table_column" key="active" allows_sorting=True %}Active{% endui %}'
+            ),
+        )
+        output, caught = self.render_with_warnings(template, {"request": request})
+        self.assertEqual(caught, [])
+        up_icon = 'd="M12 19V5M12 5L5 12M12 5L19 12"'
+        down_icon = 'd="M12 5V19M12 19L19 12M12 19L5 12"'
+        self.assertIn(up_icon, output)
+        self.assertIn(down_icon, output)
+        self.assertIn("Icon_icon Icon_variants_plain Icon_sizes_xs Table_sortIcon", output)
+        self.assertIn("Icon_icon Icon_variants_plain Icon_sizes_xs Table_sortIconUnsorted", output)
+        # Multi-sort with more than one descriptor shows sort positions
+        self.assertIn(
+            '<span class="Table_sortWrapper">'
+            '<span role="img" aria-hidden="true" class="Icon_icon Icon_variants_plain Icon_sizes_xs '
+            'Table_sortIcon"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" '
+            'xmlns="http://www.w3.org/2000/svg" focusable="false">'
+            f'<path {up_icon} stroke="currentColor" stroke-width="2" stroke-linecap="round" '
+            'stroke-linejoin="round"></path></svg></span><span>1</span></span>',
+            output,
+        )
+        self.assertIn("<span>2</span>", output)
+        # Sortable but unsorted column renders an empty position placeholder
+        self.assertIn("<span></span>", output)
+
+    def test_non_sortable_column_renders_no_sort_markup(self):
+        output, caught = self.render_with_warnings(BASIC_TABLE_TEMPLATE)
+        self.assertEqual(caught, [])
+        self.assertNotIn("aria-sort", output)
+        self.assertNotIn("Table_sortWrapper", output)
+        self.assertNotIn("<a ", output)
+
+    # --- Empty state ---
+
+    def test_empty_body_renders_default_empty_state_with_column_count(self):
+        template = (
+            '{% ui "table" aria_label="Users" %}'
+            '{% ui "table_header" %}'
+            '{% ui "table_column" %}Name{% endui %}'
+            '{% ui "table_column" %}Email{% endui %}'
+            '{% ui "table_column" %}Active{% endui %}'
+            "{% endui %}"
+            '{% ui "table_body" %}{% endui %}'
+            "{% endui %}"
+        )
+        output, caught = self.render_with_warnings(template)
+        self.assertEqual(caught, [])
+        self.assertIn(
+            '<tr><td colspan="3"><div class="Table_noResults"><em>No results</em></div></td></tr>',
+            output,
+        )
+
+    def test_empty_state_custom_content(self):
+        template = (
+            '{% ui "table" aria_label="Users" empty_state="Nothing to see" %}'
+            '{% ui "table_body" %}{% endui %}'
+            "{% endui %}"
+        )
+        output, _ = self.render_with_warnings(template)
+        self.assertIn(
+            '<tr><td colspan="1"><div class="Table_noResults">Nothing to see</div></td></tr>', output
+        )
+
+    def test_empty_state_can_be_disabled(self):
+        for disable_props in ("empty_state=False", "render_empty_state=None", "empty_state=None"):
+            with self.subTest(disable_props=disable_props):
+                template = (
+                    '{% ui "table" aria_label="Users" ' + disable_props + " %}"
+                    '{% ui "table_body" %}{% endui %}'
+                    "{% endui %}"
+                )
+                output, caught = self.render_with_warnings(template)
+                self.assertEqual(caught, [])
+                self.assertNotIn("Table_noResults", output)
+                self.assertNotIn("No results", output)
+
+    def test_user_rendered_rows_prevent_empty_state(self):
+        output, _ = self.render_with_warnings(BASIC_TABLE_TEMPLATE)
+        self.assertNotIn("Table_noResults", output)
+
+    # --- Header/footer ---
+
+    def test_header_and_footer_content_affect_wrapper_state(self):
+        template = (
+            '{% ui "table" aria_label="Users" header="<h2>People</h2>"|safe footer="Footer text" %}'
+            '{% ui "table_body" %}{% endui %}'
+            "{% endui %}"
+        )
+        output, caught = self.render_with_warnings(template)
+        self.assertEqual(caught, [])
+        self.assertIn('data-has-header="true"', output)
+        self.assertIn('data-has-footer="true"', output)
+        self.assertIn("Table_hasHeader", output)
+        self.assertNotIn("Table_hasNoHeader", output)
+        self.assertNotIn("Table_hasNoFooter", output)
+        self.assertIn("<h2>People</h2>", output)
+        self.assertIn("Footer text</div>", output)
+
+    def test_header_from_variable_is_escaped(self):
+        # Note template string literals are marked safe by Django itself (the template author
+        # wrote them); escaping applies to variable content.
+        template = (
+            '{% ui "table" aria_label="Users" header=header_content %}'
+            '{% ui "table_body" %}{% endui %}'
+            "{% endui %}"
+        )
+        output, _ = self.render_with_warnings(template, {"header_content": "<b>unsafe</b>"})
+        self.assertIn("&lt;b&gt;unsafe&lt;/b&gt;", output)
+        self.assertNotIn("<b>unsafe</b>", output)
+
+    def test_mode_edit_renders_data_attribute_only(self):
+        template = (
+            '{% ui "table" aria_label="Users" mode="edit" %}{% ui "table_body" %}{% endui %}{% endui %}'
+        )
+        output, caught = self.render_with_warnings(template)
+        self.assertEqual(caught, [])
+        self.assertIn('data-mode="edit"', output)
+
+    # --- Prop validation ---
+
+    def test_event_handler_props_warn_and_are_never_rendered(self):
+        template = (
+            '{% ui "table" aria_label="Users" onClick="alert(1)" %}'
+            '{% ui "table_header" %}'
+            '{% ui "table_column" on_click="alert(2)" %}Name{% endui %}'
+            "{% endui %}"
+            '{% ui "table_body" %}'
+            '{% ui "table_row" onclick="alert(3)" %}'
+            '{% ui "table_cell" onDoubleClick="alert(4)" %}Jane{% endui %}'
+            "{% endui %}"
+            "{% endui %}"
+            "{% endui %}"
+        )
+        output, caught = self.render_with_warnings(template)
+        for prop_name in ("onClick", "onclick", "onDoubleClick"):
+            self.assertIn(
+                f"Prop '{prop_name}' will be ignored: event handlers are not supported by "
+                "static table components",
+                caught,
+            )
+        self.assertNotIn("alert", output)
+        self.assertNotIn("onclick", output.lower())
+
+    def test_sort_callback_props_warn_with_specific_message(self):
+        template = (
+            '{% ui "table" aria_label="Users" onSortChange="handleSort" %}'
+            '{% ui "table_body" %}{% endui %}'
+            "{% endui %}"
+        )
+        output, caught = self.render_with_warnings(template)
+        self.assertIn(
+            "Prop 'onSortChange' will be ignored: client-side sort callbacks are not supported "
+            "by static table components",
+            caught,
+        )
+        self.assertNotIn("onsortchange", output.lower())
+
+    def test_selection_props_warn_and_are_ignored(self):
+        template = (
+            '{% ui "table" aria_label="Users" selection_mode="multiple" selected_keys=selected %}'
+            '{% ui "table_body" %}'
+            '{% ui "table_row" is_selected=True %}{% ui "table_cell" %}Jane{% endui %}{% endui %}'
+            "{% endui %}"
+            "{% endui %}"
+        )
+        output, caught = self.render_with_warnings(template, {"selected": [1, 2]})
+        for prop_name in ("selectionMode", "selectedKeys", "isSelected"):
+            self.assertIn(
+                f"Prop '{prop_name}' will be ignored: row selection is not supported by static "
+                "table components yet",
+                caught,
+            )
+        self.assertNotIn("data-selected", output)
+        self.assertNotIn("selectionmode", output.lower())
+
+    def test_collection_props_warn_and_are_ignored(self):
+        template = (
+            '{% ui "table" aria_label="Users" items=items columns=columns %}'
+            '{% ui "table_body" %}{% endui %}'
+            "{% endui %}"
+        )
+        output, caught = self.render_with_warnings(template, {"items": [1], "columns": ["a"]})
+        for prop_name in ("items", "columns"):
+            self.assertIn(
+                f"Prop '{prop_name}' will be ignored: collection render props are not supported "
+                "by static table components",
+                caught,
+            )
+
+    def test_data_and_aria_passthrough_only_on_supported_elements(self):
+        template = (
+            '{% ui "table" aria_label="Users" data_testid="user-table" %}'
+            '{% ui "table_header" %}'
+            '{% ui "table_column" data_testid="name-column" %}Name{% endui %}'
+            "{% endui %}"
+            '{% ui "table_body" data_testid="body" %}'
+            '{% ui "table_row" data_testid="row" aria_live="polite" %}'
+            '{% ui "table_cell" data_testid="cell" aria_current="true" %}Jane{% endui %}'
+            "{% endui %}"
+            "{% endui %}"
+            "{% endui %}"
+        )
+        output, caught = self.render_with_warnings(template)
+        # Supported on body/row/cell
+        self.assertIn('<tbody data-testid="body">', output)
+        self.assertIn('data-testid="row"', output)
+        self.assertIn('aria-live="polite"', output)
+        self.assertIn('data-testid="cell"', output)
+        self.assertIn('aria-current="true"', output)
+        # Not supported on table (other than labelling props) or column
+        self.assertNotIn('data-testid="user-table"', output)
+        self.assertNotIn('data-testid="name-column"', output)
+        self.assertIn(
+            "Prop 'data-testid' is not supported on 'table' and will be ignored",
+            caught,
+        )
+        self.assertIn(
+            "Prop 'data-testid' is not supported on 'table_column' and will be ignored",
+            caught,
+        )
+
+    def test_table_aria_labelling_props_are_supported(self):
+        template = (
+            '{% ui "table" aria_labelledby="heading-id" aria_describedby="desc-id" %}'
+            '{% ui "table_body" %}{% endui %}'
+            "{% endui %}"
+        )
+        output, caught = self.render_with_warnings(template)
+        self.assertEqual(caught, [])
+        self.assertIn('<table aria-labelledby="heading-id" aria-describedby="desc-id">', output)
+
+    def test_unknown_props_warn_and_are_dropped(self):
+        template = (
+            '{% ui "table" aria_label="Users" unknownProp="nope" %}'
+            '{% ui "table_header" unknown_header="x" %}'
+            '{% ui "table_column" unknown_column="x" %}Name{% endui %}'
+            "{% endui %}"
+            '{% ui "table_body" %}'
+            '{% ui "table_row" unknown_row="x" %}'
+            '{% ui "table_cell" unknown_cell="x" %}Jane{% endui %}'
+            "{% endui %}"
+            "{% endui %}"
+            "{% endui %}"
+        )
+        output, caught = self.render_with_warnings(template)
+        for prop_name, component_name in (
+            ("unknownProp", "table"),
+            ("unknownHeader", "table_header"),
+            ("unknownColumn", "table_column"),
+            ("unknownRow", "table_row"),
+            ("unknownCell", "table_cell"),
+        ):
+            self.assertIn(
+                f"Prop '{prop_name}' is not a supported '{component_name}' prop and will be ignored",
+                caught,
+            )
+        self.assertNotIn("nope", output)
+        self.assertNotIn("unknown", output.lower())
+
+    def test_non_scalar_prop_values_warn_and_are_ignored(self):
+        template = (
+            '{% ui "table" aria_label="Users" %}'
+            '{% ui "table_body" %}'
+            '{% ui "table_row" key=bad_value %}{% ui "table_cell" %}Jane{% endui %}{% endui %}'
+            "{% endui %}"
+            "{% endui %}"
+        )
+        output, caught = self.render_with_warnings(template, {"bad_value": {"nested": "dict"}})
+        self.assertIn(
+            "Prop 'key' with non-scalar value is not supported by static table components "
+            "and will be ignored",
+            caught,
+        )
+        self.assertNotIn("data-key", output)
+
+    # --- Fallback behaviour ---
+
+    def test_cell_outside_row_warns_and_renders_fallback(self):
+        output, caught = self.render_with_warnings('{% ui "table_cell" %}Orphan{% endui %}')
+        self.assertTrue(
+            any("'table_cell' was rendered outside" in item for item in caught),
+            caught,
+        )
+        self.assertIn('<td class="Table_cell">Orphan</td>', output)
+
+    def test_child_components_outside_table_warn_and_render_fallback(self):
+        for template, expected_fragment in (
+            ('{% ui "table_header" %}{% endui %}', "<thead>"),
+            ('{% ui "table_body" %}{% endui %}', "<tbody>"),
+            ('{% ui "table_row" %}{% endui %}', '<tr class="Table_row">'),
+        ):
+            with self.subTest(template=template):
+                output, caught = self.render_with_warnings(template)
+                self.assertTrue(
+                    any("was rendered outside of a" in item for item in caught),
+                    caught,
+                )
+                self.assertIn(expected_fragment, output)
+
+    def test_extra_cells_warn_once_per_table_and_render(self):
+        template = (
+            '{% ui "table" aria_label="Users" %}'
+            '{% ui "table_header" %}{% ui "table_column" %}Name{% endui %}{% endui %}'
+            '{% ui "table_body" %}'
+            '{% ui "table_row" %}'
+            '{% ui "table_cell" %}Jane{% endui %}'
+            '{% ui "table_cell" %}extra-1{% endui %}'
+            '{% ui "table_cell" %}extra-2{% endui %}'
+            "{% endui %}"
+            "{% endui %}"
+            "{% endui %}"
+        )
+        output, caught = self.render_with_warnings(template)
+        extra_cell_warnings = [item for item in caught if "more 'table_cell' components" in item]
+        self.assertEqual(len(extra_cell_warnings), 1)
+        self.assertIn('<td class="Table_cell">extra-1</td>', output)
+        self.assertIn('<td class="Table_cell">extra-2</td>', output)
+
+    def test_cell_colspan_consumes_multiple_columns(self):
+        template = (
+            '{% ui "table" aria_label="Users" %}'
+            '{% ui "table_header" %}'
+            '{% ui "table_column" %}Name{% endui %}'
+            '{% ui "table_column" %}Email{% endui %}'
+            '{% ui "table_column" align="end" %}Total{% endui %}'
+            "{% endui %}"
+            '{% ui "table_body" %}'
+            '{% ui "table_row" %}'
+            '{% ui "table_cell" col_span=2 %}Jane{% endui %}'
+            '{% ui "table_cell" %}10{% endui %}'
+            "{% endui %}"
+            "{% endui %}"
+            "{% endui %}"
+        )
+        output, caught = self.render_with_warnings(template)
+        self.assertEqual(caught, [])
+        self.assertIn('<td class="Table_cell" colspan="2" role="rowheader">Jane</td>', output)
+        # The cell after a colspan=2 cell inherits metadata from the third column
+        self.assertIn('<td class="Table_cell Table_alignEnd" data-align="end">10</td>', output)
+
+    def test_nested_table_in_cell_uses_its_own_state(self):
+        inner_table = (
+            '{% ui "table" aria_label="Inner" %}'
+            '{% ui "table_header" %}{% ui "table_column" align="end" %}Inner col{% endui %}{% endui %}'
+            '{% ui "table_body" %}'
+            '{% ui "table_row" %}{% ui "table_cell" %}inner-cell{% endui %}{% endui %}'
+            "{% endui %}"
+            "{% endui %}"
+        )
+        template = (
+            '{% ui "table" aria_label="Outer" %}'
+            '{% ui "table_header" %}'
+            '{% ui "table_column" %}Name{% endui %}'
+            '{% ui "table_column" %}Details{% endui %}'
+            "{% endui %}"
+            '{% ui "table_body" %}'
+            '{% ui "table_row" %}'
+            '{% ui "table_cell" %}Jane{% endui %}'
+            '{% ui "table_cell" %}' + inner_table + "{% endui %}"
+            "{% endui %}"
+            "{% endui %}"
+            "{% endui %}"
+        )
+        output, caught = self.render_with_warnings(template)
+        self.assertEqual(caught, [])
+        # Inner cell is the inner table's first column: row header with alignEnd from inner column
+        self.assertIn(
+            '<td class="Table_cell Table_alignEnd" data-align="end" role="rowheader">inner-cell</td>',
+            output,
+        )
+        # The outer table's empty state/row counting is unaffected
+        self.assertNotIn("Table_noResults", output)
+
+    def test_colspan_on_column_renders_spans_multiple(self):
+        template = make_sortable_table_template(columns='{% ui "table_column" col_span=2 %}Name{% endui %}')
+        output, caught = self.render_with_warnings(template)
+        self.assertEqual(caught, [])
+        self.assertIn(
+            '<th class="Table_headerCell Table_spansMultiple" data-spans-multiple="true" '
+            'colspan="2" scope="col">',
+            output,
+        )
+
+    def test_compiled_template_is_reusable_across_renders(self):
+        # Template nodes are shared between renders (and threads); the components must not carry
+        # per-render state on the node instances. Render one compiled Template repeatedly and
+        # check render-dependent output (empty state, sort links) is correct every time.
+        outputs = []
+        with self.setup_render_context():
+            template_obj = Template(
+                "{% load alliance_platform.ui %}"
+                + make_sortable_table_template('sort_order=request|table_sort_order sort_mode="single"')
+                + '{% ui "table" aria_label="Empty" %}'
+                '{% ui "table_header" %}{% ui "table_column" %}Name{% endui %}{% endui %}'
+                '{% ui "table_body" %}{% endui %}'
+                "{% endui %}"
+            )
+            for url in ("/users/", "/users/?ordering=name", "/users/"):
+                context_obj = Context({"request": self.request_factory.get(url)})
+                context_obj.template = template_obj
+                outputs.append(template_obj.render(context_obj))
+        first_render, second_render, third_render = outputs
+        self.assertIn('href="/users/?ordering=name"', first_render)
+        self.assertIn('href="/users/?ordering=-name"', second_render)
+        # Repeating the first request must reproduce the first output exactly (no leaked state)
+        self.assertEqual(third_render, first_render)
+        for output in outputs:
+            self.assertIn("<em>No results</em>", output)
+
+    def test_resources_are_registered(self):
+        with self.setup_render_context() as asset_context:
+            self.render_ui_template(BASIC_TABLE_TEMPLATE)
+            resource_paths = [str(resource.path) for resource in asset_context.get_resources_for_bundling()]
+        self.assertTrue(
+            any(
+                path.endswith("@alliancesoftware/ui/components/table/Table.css.ts") for path in resource_paths
+            )
+        )
+        self.assertTrue(any(path.endswith("@alliancesoftware/icons/Icon.css.ts") for path in resource_paths))

--- a/packages/ap-ui/tests/test_html_ui_table_parity.py
+++ b/packages/ap-ui/tests/test_html_ui_table_parity.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from django.test import RequestFactory
+
+from tests.parity.base import HtmlUIParityTestCase
+
+
+class UITableParityTestCase(HtmlUIParityTestCase):
+    fixture_component = "table"
+
+    request_factory = RequestFactory()
+
+    def test_fixture_cases(self):
+        fixture = self.load_fixture()
+        for case in fixture["cases"]:
+            with self.subTest(case=case["name"]):
+                # Sortable cases record the URL the React render happened at (ColumnHeaderLink
+                # reads it from the SSR context); build the matching request for the static
+                # renderer's URL generation.
+                context_kwargs = None
+                current_url = case.get("meta", {}).get("current_url")
+                if current_url:
+                    context_kwargs = {"request": self.request_factory.get(current_url)}
+                self.assert_parity_case(case, context_kwargs)
+
+    def test_resources_are_registered(self):
+        with self.setup_render_context() as asset_context:
+            self.render_ui_template(
+                '{% ui "table" aria_label="Users" %}{% ui "table_body" %}{% endui %}{% endui %}'
+            )
+            resource_paths = [str(resource.path) for resource in asset_context.get_resources_for_bundling()]
+
+        self.assertTrue(
+            any(
+                path.endswith("@alliancesoftware/ui/components/table/Table.css.ts") for path in resource_paths
+            )
+        )
+        self.assertTrue(any(path.endswith("@alliancesoftware/icons/Icon.css.ts") for path in resource_paths))


### PR DESCRIPTION
Adds {% ui "table" %} / table_header / table_body / table_column / table_row / table_cell for read-only CRUD list views: same markup, vanilla-extract classes and state data attributes as the React Table, with no JavaScript runtime. Sortable columns render plain links that update a backend query parameter, matching the useTableSorter cycle (single/multiple modes, toggle/replace behaviour) and preserving unrelated query params. Column metadata (alignment, row header) is tracked through a render state stack in context.render_context and inherited by body cells; empty bodies render the default empty state.

Native table semantics are used instead of the React ARIA grid (no grid roles/tab indexes; scope="col" and aria-sort on headers; row-header cells as <td role="rowheader">). Selection, client-side sorting and collection props warn and are dropped. Parity fixtures pin the renderer against React SSR output, generated against the alliance-platform-js branch carrying the Table aria-sort/ColumnHeaderLink fixes; the fixture drift workflow can now pin the alliance-platform-js ref via .github/alliance-platform-js-ref (or a js_ref dispatch input) so cross-repo changes are testable in CI before the JS side merges.